### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: test
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Promptly-Technologies-LLC/imfp/security/code-scanning/1](https://github.com/Promptly-Technologies-LLC/imfp/security/code-scanning/1)

The best way to address this issue is to specify a permissions block granting only the minimum set of privileges the workflow requires. For this workflow, none of the listed steps need write access to repository contents, issues, pull requests, or other privileged resources. Therefore, setting `permissions: contents: read` will suffice. This can be applied either at the workflow root (recommended if there is only one job), or inside the `test` job. To match best practices and your example, add the following block after the workflow name at the top:

```yaml
permissions:
  contents: read
```

Specifically, in .github/workflows/test.yml, insert the permissions block between line 1 (`name: test`) and line 3 (`on:`). No imports or additional dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
