### PR TITLE
Set up Cursor Cloud dev environment for imfp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`imfp` is a pure Python client library (no server, database, or GUI) for downloading
+economic data from the IMF SDMX 3.0 JSON API (`https://api.imf.org/external/sdmx/3.0/`).
+Dependencies are managed with [uv](https://astral.sh/uv) (`pyproject.toml` + `uv.lock`);
+the update script runs `uv sync`, which creates/refreshes the `.venv`.
+
+Run everything through `uv run` (do not activate the venv manually). Key commands:
+
+- Tests: `uv run pytest tests` — fully offline. `tests/conftest.py` mocks HTTP by hashing
+  request URLs (SHA256) and replaying cached JSON from `tests/responses/`, so no network
+  or API key is needed.
+- Format check: `uv run black --check .` (CI's `format.yml` auto-formats on push via
+  action-black, so a local reformat finding is expected, not a setup failure).
+- Type check: `uv run mypy imfp` (config in `mypy.ini`).
+- Build: `uv build` (wheel + sdist into `dist/`).
+- Live smoke test / real usage: `uv run python -c "import imfp; print(len(imfp.imf_databases()))"`.
+
+Notes:
+
+- Live calls (`imf_databases()`, `imf_parameters()`, `imf_dataset()`) hit the public IMF API
+  and require outbound network; `imf_dataset()` for a large database can take ~30-60s because
+  of built-in rate limiting (default 1.5s between requests, tunable via `IMF_WAIT_TIME`).
+- Optional env vars (see `imfp/admin.py`): `IMF_APP_NAME` (custom request header to reduce
+  rate-limiting) and `IMF_WAIT_TIME`. Neither is required for tests.
+- Documentation is built with the external Quarto CLI (`uv run quarto render`, per CI
+  `test.yml`). Quarto is not installed by the update script; install it only if editing docs.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for the `imfp` Python library and documents it for future agents.

- Installed `uv` and ran `uv sync` to create the `.venv` with all runtime + dev dependencies.
- Verified lint (`black`), type check (`mypy`), test suite (`pytest`), build (`uv build`), and a live end-to-end fetch against the IMF API all run.
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering how to run/test/lint/build the library and non-obvious caveats (offline-mocked tests, live-API rate limiting, optional Quarto docs).

Note: `AGENTS.md` is listed in `.gitignore`, so it was force-added. If you prefer not to track it, feel free to drop that file from the PR.

## Environment role split

- Update script (runs on every VM startup): `uv sync` — minimal, idempotent dependency refresh.
- `AGENTS.md`: durable run/test/build guidance and gotchas for future agents.

## Verification

- `uv run black --check .` → runs (pre-existing reformat finding in `imfp/data.py`; CI `format.yml` auto-formats on push).
- `uv run mypy imfp` → runs (pre-existing missing-stub findings).
- `uv run pytest tests` → 20 passed (offline, HTTP mocked).
- `uv build` → builds wheel + sdist into `dist/`.
- Hello world: `imfp.imf_databases()` returned 222 databases and `imfp.imf_dataset("PCPS", frequency=["A"], start_year=2000, end_year=2015)` returned a 12,820-row DataFrame from the live IMF API.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86bd1757-f7c1-4008-906e-1ded6ba594f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86bd1757-f7c1-4008-906e-1ded6ba594f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

