### PR TITLE
Add py.typed for PEP 561 typed package support (#88)

### DIFF
--- a/imfp/data.py
+++ b/imfp/data.py
@@ -1,5 +1,5 @@
 import logging
-from typing import overload, Literal
+from typing import Any, overload, Literal
 from warnings import warn
 from urllib.parse import urlencode
 from pandas import DataFrame
@@ -16,7 +16,7 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
-def _parse_imf_sdmx_json(message: dict) -> DataFrame:
+def _parse_imf_sdmx_json(message: dict[str, Any]) -> DataFrame:
     """
     Parse SDMX JSON message from new API into a DataFrame.
 
@@ -47,7 +47,7 @@ def _parse_imf_sdmx_json(message: dict) -> DataFrame:
     obs_dim = obs_dims[0] if obs_dims and len(obs_dims) >= 1 else None
 
     # Helper to map index -> code/id
-    def index_to_code(dim_def, idx):
+    def index_to_code(dim_def: dict[str, Any] | None, idx: Any) -> Any:
         if not dim_def or not dim_def.get("values") or len(dim_def["values"]) < 1:
             return None
         try:
@@ -60,7 +60,7 @@ def _parse_imf_sdmx_json(message: dict) -> DataFrame:
         except (ValueError, IndexError, TypeError):
             return None
 
-    def obs_index_to_period(idx):
+    def obs_index_to_period(idx: Any) -> Any:
         if not obs_dim or not obs_dim.get("values") or len(obs_dim["values"]) < 1:
             return None
         try:
@@ -179,7 +179,7 @@ def imf_databases(times: int = 3) -> DataFrame:
     database_id = []
     description = []
 
-    def _extract_first(value):
+    def _extract_first(value: Any) -> Any:
         """Extract first element from list, or return value if not a list."""
         if isinstance(value, list) and len(value) > 0:
             return value[0]
@@ -249,9 +249,10 @@ def imf_parameters(database_id: str, times: int = 2) -> dict[str, DataFrame]:
         else:
             raise ValueError(e)
 
-    def fetch_parameter_data(k, times):
-        codelist_id = codelist.loc[k, "code"]
-        codelist_agency = codelist.loc[k, "agency"]
+    def fetch_parameter_data(k: int, times: int) -> DataFrame:
+        codelist_id = str(codelist.loc[k, "code"])
+        agency_raw = codelist.loc[k, "agency"]
+        codelist_agency = None if agency_raw is None else str(agency_raw)
 
         # Fetch codelist using new API
         # Try agency-specific path first to get the correct version,
@@ -302,8 +303,8 @@ def imf_parameters(database_id: str, times: int = 2) -> dict[str, DataFrame]:
             }
         )
 
-    parameter_list = {
-        codelist.loc[k, "parameter"]: fetch_parameter_data(k, times)
+    parameter_list: dict[str, DataFrame] = {
+        str(codelist.loc[k, "parameter"]): fetch_parameter_data(k, times)
         for k in range(codelist.shape[0])
     }
 
@@ -362,45 +363,43 @@ def imf_parameter_defs(
 @overload
 def imf_dataset(
     database_id: str,
-    parameters: dict | None = None,
+    parameters: dict[str, DataFrame] | None = None,
     start_year: int | str | None = None,
     end_year: int | str | None = None,
     return_raw: bool = False,
     print_url: bool = False,
     times: int = 3,
     include_metadata: Literal[False] = False,
-    **kwargs,
-) -> DataFrame:
-    ...
+    **kwargs: Any,
+) -> DataFrame: ...
 
 
 @overload
 def imf_dataset(
     database_id: str,
-    parameters: dict | None = None,
+    parameters: dict[str, DataFrame] | None = None,
     start_year: int | str | None = None,
     end_year: int | str | None = None,
     return_raw: bool = False,
     print_url: bool = False,
     times: int = 3,
     include_metadata: Literal[True] = True,
-    **kwargs,
-) -> tuple[dict, DataFrame]:
-    ...
+    **kwargs: Any,
+) -> tuple[dict[str, Any], DataFrame]: ...
 
 
 @type_enforced.Enforcer
 def imf_dataset(
     database_id: str,
-    parameters: dict | None = None,
+    parameters: dict[str, DataFrame] | None = None,
     start_year: int | str | None = None,
     end_year: int | str | None = None,
     return_raw: bool = False,
     print_url: bool = False,
     times: int = 3,
     include_metadata: bool = False,
-    **kwargs,
-) -> DataFrame | tuple[dict, DataFrame]:
+    **kwargs: Any,
+) -> DataFrame | dict[str, Any] | tuple[dict[str, Any], DataFrame | dict[str, Any]]:
     """
     Download a data series from the IMF.
 
@@ -678,7 +677,9 @@ def imf_dataset(
     key = ".".join(segments)
 
     # Helper to transform time periods for API compatibility
-    def transform_period_for_frequency(period, frequency):
+    def transform_period_for_frequency(
+        period: str | None, frequency: list[str] | None
+    ) -> str | None:
         if not period:
             return period
 
@@ -764,7 +765,7 @@ def imf_dataset(
     if return_raw:
         if include_metadata:
             # For now, return empty metadata dict (could be enhanced later)
-            metadata = {}
+            metadata: dict[str, Any] = {}
             return metadata, message
         else:
             return message

--- a/imfp/data.py
+++ b/imfp/data.py
@@ -425,7 +425,8 @@ def imf_dataset(
     times: int = 3,
     include_metadata: Literal[False] = False,
     **kwargs: Any,
-) -> DataFrame: ...
+) -> DataFrame:
+    ...
 
 
 @overload
@@ -439,7 +440,8 @@ def imf_dataset(
     times: int = 3,
     include_metadata: Literal[True] = True,
     **kwargs: Any,
-) -> tuple[dict[str, Any], DataFrame]: ...
+) -> tuple[dict[str, Any], DataFrame]:
+    ...
 
 
 @type_enforced.Enforcer

--- a/imfp/data.py
+++ b/imfp/data.py
@@ -371,7 +371,8 @@ def imf_dataset(
     times: int = 3,
     include_metadata: Literal[False] = False,
     **kwargs: Any,
-) -> DataFrame: ...
+) -> DataFrame:
+    ...
 
 
 @overload
@@ -385,7 +386,8 @@ def imf_dataset(
     times: int = 3,
     include_metadata: Literal[True] = True,
     **kwargs: Any,
-) -> tuple[dict[str, Any], DataFrame]: ...
+) -> tuple[dict[str, Any], DataFrame]:
+    ...
 
 
 @type_enforced.Enforcer

--- a/imfp/utils.py
+++ b/imfp/utils.py
@@ -1,25 +1,31 @@
 from os import environ, path
 import hashlib
 from time import sleep, perf_counter
-from requests import get
+from requests import get, Response
 from json import loads, load, dump, JSONDecodeError
 from pandas import DataFrame
 from urllib.parse import urlparse, urljoin
 import re
 import logging
-from typing import Optional
+from collections.abc import Callable
+from typing import Any, Optional, ParamSpec, TypeVar
 
 logger = logging.getLogger(__name__)
 
 # New IMF API base URL
 IMF_API_BASE_URL = "https://api.imf.org/external/sdmx/3.0/"
 
+P = ParamSpec("P")
+R = TypeVar("R")
 
-def _min_wait_time_limited(default_wait_time=1.5):
-    def decorator(func):
+
+def _min_wait_time_limited(
+    default_wait_time: float = 1.5,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         last_called = [0.0]
 
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             min_wait_time = float(environ.get("IMF_WAIT_TIME", default_wait_time))
             elapsed = perf_counter() - last_called[0]
             left_to_wait = min_wait_time - elapsed
@@ -35,7 +41,9 @@ def _min_wait_time_limited(default_wait_time=1.5):
 
 
 @_min_wait_time_limited()
-def _imf_get(url, headers, timeout=None):
+def _imf_get(
+    url: str, headers: dict[str, str], timeout: Optional[float] = None
+) -> Response:
     """
     A rate-limited wrapper around the requests.get method.
 
@@ -64,13 +72,13 @@ _imf_save_response = False
 
 
 def _download_parse(
-    resource_or_url,
-    times=3,
-    base_url=None,
-    query_params=None,
-    timeout_seconds=30.0,
-    low_speed_seconds=15.0,
-):
+    resource_or_url: str,
+    times: int = 3,
+    base_url: Optional[str] = None,
+    query_params: Optional[dict[str, Any]] = None,
+    timeout_seconds: float = 30.0,
+    low_speed_seconds: float = 15.0,
+) -> dict[str, Any]:
     """
     (Internal) Download and parse JSON content from the IMF API with rate limiting
     and retries.
@@ -163,7 +171,7 @@ def _download_parse(
             cached_status, cached_content = _load_cached_response(url)
             if cached_content is not None:
                 content = cached_content
-                status = cached_status
+                status = 0 if cached_status is None else cached_status
             else:
                 response = _imf_get(url, headers=headers, timeout=timeout_seconds)
                 content = response.text
@@ -294,8 +302,12 @@ def _download_parse(
                             f"Content preview: {preview}"
                         )
 
+    raise ValueError(
+        f"Content from API could not be parsed as JSON. Resource={resource}."
+    )
 
-def _load_cached_response(URL):
+
+def _load_cached_response(URL: str) -> tuple[Optional[int], Optional[str]]:
     file_name = hashlib.sha256(URL.encode()).hexdigest()
     file_path = f"tests/responses/{file_name}.json"
 
@@ -306,7 +318,7 @@ def _load_cached_response(URL):
     return None, None
 
 
-def _extract_first(value):
+def _extract_first(value: Any) -> Any:
     """Extract first element from list, or return value if not a list.
 
     This matches R's [[1]] behavior for extracting scalar values from lists.
@@ -400,7 +412,7 @@ def _parse_codelist_urn(urn: str) -> dict[str, Optional[str]]:
     }
 
 
-def _get_datastructure_components(dataflow_id: str, times: int = 3) -> dict:
+def _get_datastructure_components(dataflow_id: str, times: int = 3) -> dict[str, Any]:
     """
     (Internal) Retrieve raw datastructure components for a dataflow.
 
@@ -464,7 +476,9 @@ def _get_datastructure_components(dataflow_id: str, times: int = 3) -> dict:
     return components
 
 
-def _imf_dimensions(database_id, times=3, inputs_only=True):
+def _imf_dimensions(
+    database_id: str, times: int = 3, inputs_only: bool = True
+) -> DataFrame:
     """
     (Internal) Retrieve the list of codes for dimensions of an individual IMF
     database.
@@ -695,7 +709,7 @@ def _imf_dimensions(database_id, times=3, inputs_only=True):
     return result_df
 
 
-def _imf_metadata(database_id, times=3):
+def _imf_metadata(database_id: str, times: int = 3) -> dict[str, Any]:
     """
     (Internal) Access metadata for a dataset.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,6 @@
 [mypy]
+disallow_untyped_defs = True
+warn_unused_ignores = True
 
 [mypy-type_enforced.*]
 ignore_missing_imports = True 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+    "Typing :: Typed",
 ]
 requires-python = ">=3.10"
 dependencies = [
@@ -31,6 +32,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["imfp"]
+
+[tool.setuptools.package-data]
+imfp = ["py.typed"]
 
 [tool.semantic_release]
 assets = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,4 +138,6 @@ dev = [
     "numpy>=2.1.3",
     "python-semantic-release>=10.5.2",
     "great-docs>=0.14.1 ; python_full_version >= '3.11'",
+    "types-requests>=2.33.0.20260712",
+    "pandas-stubs>=2.3.3.260113",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -915,6 +915,8 @@ dev = [
     { name = "nbconvert" },
     { name = "notebook" },
     { name = "numpy" },
+    { name = "pandas-stubs", version = "2.3.3.260113", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas-stubs", version = "3.0.5.260730", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
     { name = "pyarrow" },
     { name = "pycountry" },
@@ -930,6 +932,7 @@ dev = [
     { name = "statsmodels" },
     { name = "tabulate" },
     { name = "tornado" },
+    { name = "types-requests" },
     { name = "urllib3" },
 ]
 
@@ -953,6 +956,7 @@ dev = [
     { name = "nbconvert", specifier = ">=7.17.1" },
     { name = "notebook", specifier = ">=7.5.6" },
     { name = "numpy", specifier = ">=2.1.3" },
+    { name = "pandas-stubs", specifier = ">=2.3.3.260113" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pyarrow", specifier = ">=23.0.1" },
     { name = "pycountry", specifier = ">=24.6.1" },
@@ -968,6 +972,7 @@ dev = [
     { name = "statsmodels", specifier = ">=0.14.5" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "tornado", specifier = ">=6.5.7" },
+    { name = "types-requests", specifier = ">=2.33.0.20260712" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
@@ -2008,6 +2013,39 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/25/b0/98d6ae2e1abac4f35230aa756005e8654649d305df9a28b16b9ae4353bff/pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4", size = 11871013, upload-time = "2024-09-20T13:09:44.39Z" },
     { url = "https://files.pythonhosted.org/packages/cc/57/0f72a10f9db6a4628744c8e8f0df4e6e21de01212c7c981d31e50ffc8328/pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d", size = 15711620, upload-time = "2024-09-20T19:02:20.639Z" },
     { url = "https://files.pythonhosted.org/packages/ab/5f/b38085618b950b79d2d9164a711c52b10aefc0ae6833b96f626b7021b2ed/pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a", size = 13098436, upload-time = "2024-09-20T13:09:48.112Z" },
+]
+
+[[package]]
+name = "pandas-stubs"
+version = "2.3.3.260113"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy" },
+    { name = "types-pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c6/df1fe324248424f77b89371116dab5243db7f052c32cc9fe7442ad9c5f75/pandas_stubs-2.3.3.260113-py3-none-any.whl", hash = "sha256:ec070b5c576e1badf12544ae50385872f0631fc35d99d00dc598c2954ec564d3", size = 168246, upload-time = "2026-01-13T22:30:15.244Z" },
+]
+
+[[package]]
+name = "pandas-stubs"
+version = "3.0.5.260730"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/d2/dea4a3a56b7b5f69c5fbca9f14625fcf28e1a39a657e9833d4a10bcac593/pandas_stubs-3.0.5.260730.tar.gz", hash = "sha256:f70a232c57d93a5a2c81f8a53953e10891a5374bc92652277deb325e2e4d0ff3", size = 114631, upload-time = "2026-07-30T14:31:42.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/c2/959caec5c46f484b5f8bb6def4b0cf7a45ba6acda26f12b75142d98cc5ae/pandas_stubs-3.0.5.260730-py3-none-any.whl", hash = "sha256:60e90e3e1eda6937e337e243cbe6217e151c11137cd7eddf832af537c7310bfd", size = 174807, upload-time = "2026-07-30T14:31:41.17Z" },
 ]
 
 [[package]]
@@ -3496,12 +3534,33 @@ wheels = [
 ]
 
 [[package]]
+name = "types-pytz"
+version = "2026.3.1.20260727"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/cf/eae96172a036b942e0ad0ec49512108b4ef4b97cd6c2aed5677540a597e7/types_pytz-2026.3.1.20260727.tar.gz", hash = "sha256:4364075b6867dd15b210bb8c1d29727d609917129b45600defe1d4b3eda5ecb9", size = 10914, upload-time = "2026-07-27T05:36:32.389Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/24/a654176875944981c75516857cd8750600eeb9ff7fc07a2b82573619a57c/types_pytz-2026.3.1.20260727-py3-none-any.whl", hash = "sha256:42ac44e83645bfceb46597342c8fb8ec028a1407e2feae9c5c539986eab6b57a", size = 10132, upload-time = "2026-07-27T05:36:31.52Z" },
+]
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20250915"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260712"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/51/703318f7b7be8bee126ec13bf615050f932d0179b8784420f3a0199cc769/types_requests-2.33.0.20260712.tar.gz", hash = "sha256:2141b67ab534a5c5cd2dac5034f2a35f42e699c5bf185eee608c5246a069d7fb", size = 25084, upload-time = "2026-07-12T05:14:20.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/e7/010c87f559e216d83f9dc51e939633fd0d0ead3377340181ab0e223cd3b5/types_requests-2.33.0.20260712-py3-none-any.whl", hash = "sha256:de027e28c171d3da529689cbfa023b0b4eab188c8dfa22fd834eebd2cee6e7bb", size = 21392, upload-time = "2026-07-12T05:14:19.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add an empty `imfp/py.typed` marker so type checkers treat installed `imfp` as a typed package (PEP 561).
- Include `py.typed` via `[tool.setuptools.package-data]` so it is shipped in wheels/sdists.
- Add the `Typing :: Typed` classifier.

Closes #88

## Test plan

- [x] `uv run pytest tests`
- [x] `uv run mypy imfp`
- [x] `uv build` and confirm `imfp/py.typed` is present in the wheel

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86a2d06f-5745-4d3a-ae19-5e8904ef5d7c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86a2d06f-5745-4d3a-ae19-5e8904ef5d7c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

