### PR TITLE
Simplify imf_dataset with regression tests (issue #68)

### DIFF
--- a/imfp/data.py
+++ b/imfp/data.py
@@ -370,7 +370,8 @@ def imf_dataset(
     times: int = 3,
     include_metadata: Literal[False] = False,
     **kwargs,
-) -> DataFrame: ...
+) -> DataFrame:
+    ...
 
 
 @overload
@@ -384,7 +385,8 @@ def imf_dataset(
     times: int = 3,
     include_metadata: Literal[True] = True,
     **kwargs,
-) -> tuple[dict, DataFrame]: ...
+) -> tuple[dict, DataFrame]:
+    ...
 
 
 @overload
@@ -398,7 +400,8 @@ def imf_dataset(
     times: int = 3,
     include_metadata: Literal[False] = False,
     **kwargs,
-) -> dict: ...
+) -> dict:
+    ...
 
 
 @overload
@@ -412,7 +415,8 @@ def imf_dataset(
     times: int = 3,
     include_metadata: Literal[True] = True,
     **kwargs,
-) -> tuple[dict, dict]: ...
+) -> tuple[dict, dict]:
+    ...
 
 
 @type_enforced.Enforcer

--- a/imfp/data.py
+++ b/imfp/data.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import overload, Literal
 from warnings import warn
 from urllib.parse import urlencode
@@ -9,11 +10,18 @@ from .utils import (
     _download_parse,
     _imf_dimensions,
     _extract_first,
+    _find_dataflow,
     _get_datastructure_components,
     IMF_API_BASE_URL,
 )
 
 logger = logging.getLogger(__name__)
+
+_FREQ_ALIASES = ("freq", "frequency")
+_REF_AREA_ALIASES = ("ref_area", "refarea", "ref-area", "country", "geo")
+_PERIOD_FREQ_SUFFIX = re.compile(r"^\d{4}-(M|Q|A|W)\d+$")
+_PERIOD_MONTH = re.compile(r"^\d{4}-\d{2}$")
+_PERIOD_YEAR = re.compile(r"^\d{4}$")
 
 
 def _parse_imf_sdmx_json(message: dict) -> DataFrame:
@@ -142,6 +150,195 @@ def _parse_imf_sdmx_json(message: dict) -> DataFrame:
     return df
 
 
+def _normalize_year_arg(value, arg_name: str) -> str | None:
+    """Validate and normalize a four-digit year argument to a string."""
+    if value is None:
+        return None
+    if arg_name == "start_year":
+        message = "start_year must be a four-digit number, either integer or string."
+    else:
+        message = "end_year must be a four-digit number, either integer or string"
+    try:
+        year = str(value)
+        if year.isdigit() and len(year) == 4:
+            return year
+        raise ValueError(message)
+    except Exception:
+        raise ValueError(message)
+
+
+def _map_parameter_alias(key: str, available_keys: set[str]) -> str:
+    """Map a legacy/alias parameter name onto a dataset-specific key."""
+    kl = key.lower()
+    if kl in available_keys:
+        return kl
+    for aliases in (_FREQ_ALIASES, _REF_AREA_ALIASES):
+        if kl in aliases:
+            for cand in aliases:
+                if cand in available_keys:
+                    if cand != kl:
+                        warn(f"Coercing parameter '{key}' to '{cand}' for this dataset")
+                    return cand
+    return kl
+
+
+def _coerce_input_keys_for_dataset(input_dict: dict, available_keys: set[str]) -> dict:
+    """Coerce legacy input parameter names to dataset-specific keys."""
+    coerced: dict = {}
+    for k, v in input_dict.items():
+        new_k = _map_parameter_alias(k, available_keys)
+        if new_k in coerced and new_k != k:
+            warn(f"Duplicate values for '{new_k}' after coercion; keeping the first")
+            continue
+        coerced[new_k] = v
+    return coerced
+
+
+def _codes_from_parameters(parameters: dict) -> dict[str, list]:
+    return {key: list(frame["input_code"]) for key, frame in parameters.items()}
+
+
+def _codes_from_kwargs(kwargs: dict) -> dict[str, list]:
+    selected: dict[str, list] = {}
+    for key, value in kwargs.items():
+        selected[key] = value if isinstance(value, list) else [value]
+    return selected
+
+
+def _apply_selected_codes(
+    data_dimensions: dict[str, DataFrame],
+    selected: dict[str, list],
+    database_id: str,
+) -> None:
+    """Filter data_dimensions in place to the selected input codes."""
+    for key, codes in selected.items():
+        if key not in data_dimensions:
+            raise ValueError(
+                f"{key} not valid parameter(s) for the "
+                f"{database_id} database. Use "
+                f"imf_parameters('{database_id}') to get "
+                "valid parameters."
+            )
+        valid_codes = data_dimensions[key]["input_code"].tolist()
+        invalid = [x for x in codes if x not in valid_codes]
+        if invalid:
+            warn(
+                f"{invalid} not valid value(s) for {key} and will "
+                f"be ignored. Use imf_parameters('{database_id}') to get "
+                "valid parameters."
+            )
+        # Empty or all-codes selection means "no filter" (wildcard in the key).
+        if set(codes) == set(valid_codes) or len(codes) == 0:
+            data_dimensions[key] = data_dimensions[key].iloc[0:0]
+        else:
+            data_dimensions[key] = data_dimensions[key][
+                data_dimensions[key]["input_code"].isin(codes)
+            ]
+
+    for key in data_dimensions:
+        if key not in selected:
+            data_dimensions[key] = data_dimensions[key].iloc[0:0]
+
+
+def _normalized_dimension_filters(
+    data_dimensions: dict[str, DataFrame],
+) -> dict[str, list]:
+    return {
+        key.upper(): codes
+        for key, frame in data_dimensions.items()
+        if (codes := frame["input_code"].tolist())
+    }
+
+
+def _series_key_rows(components: dict) -> list[dict]:
+    """Return non-time dimensions sorted by position for series-key construction."""
+    dims = components.get("dimensionList", {}).get("dimensions", [])
+    time_dims = components.get("dimensionList", {}).get("timeDimensions", [])
+    all_dim_rows = []
+    for dim in list(dims) + list(time_dims or []):
+        if not dim:
+            continue
+        dim_id = _extract_first(dim.get("id"))
+        position = dim.get("position")
+        dim_type = _extract_first(dim.get("type"))
+        if dim_id and position is not None:
+            all_dim_rows.append(
+                {
+                    "id": dim_id.upper(),
+                    "position": int(position),
+                    "type": dim_type,
+                }
+            )
+    key_rows = [row for row in all_dim_rows if row["type"] != "TimeDimension"]
+    key_rows.sort(key=lambda x: x["position"])
+    return key_rows
+
+
+def _build_series_key(key_rows: list[dict], norm_dims: dict[str, list]) -> str:
+    available_dims = {row["id"] for row in key_rows}
+    unknown = set(norm_dims) - available_dims
+    if unknown:
+        raise ValueError(
+            f"Unknown dimension(s): {', '.join(sorted(unknown))}. "
+            f"Available dimensions: {', '.join(sorted(available_dims))}"
+        )
+    segments = []
+    for row in key_rows:
+        vals = norm_dims.get(row["id"], [])
+        segments.append("*" if not vals else "+".join(vals))
+    return ".".join(segments)
+
+
+def _transform_period_for_frequency(period, frequency):
+    """Transform a user time period into the SDMX filter form for a frequency."""
+    if not period:
+        return period
+    if _PERIOD_FREQ_SUFFIX.match(period):
+        return period
+    if _PERIOD_MONTH.match(period):
+        year, month = period.split("-")
+        return f"{year}-M{month}"
+    if _PERIOD_YEAR.match(period):
+        if frequency and len(frequency) == 1:
+            freq_map = {"A": "-A1", "Q": "-Q1", "M": "-M01", "W": "-W01"}
+            suffix = freq_map.get(frequency[0].upper(), "-A1")
+        else:
+            suffix = "-A1"
+        return f"{period}{suffix}"
+    return period
+
+
+def _build_time_query_params(
+    start_period: str | None,
+    end_period: str | None,
+    user_frequency,
+    provider_agency: str,
+) -> dict[str, str]:
+    query_params = {
+        "dimensionAtObservation": "TIME_PERIOD",
+        "attributes": "dsd",
+        "measures": "all",
+    }
+    time_filters = []
+    if start_period:
+        time_filters.append(
+            f"ge:{_transform_period_for_frequency(start_period, user_frequency)}"
+        )
+    if end_period:
+        time_filters.append(
+            f"le:{_transform_period_for_frequency(end_period, user_frequency)}"
+        )
+    if time_filters:
+        if provider_agency == "IMF.STA":
+            query_params["c[TIME_PERIOD]"] = "+".join(time_filters)
+        else:
+            warn(
+                f"Agency {provider_agency} does not support time filters; "
+                "time window will be ignored."
+            )
+    return query_params
+
+
 @type_enforced.Enforcer
 def imf_databases(times: int = 3) -> DataFrame:
     """
@@ -178,12 +375,6 @@ def imf_databases(times: int = 3) -> DataFrame:
     # In the R implementation, these are lists and we take the first element [[1]]
     database_id = []
     description = []
-
-    def _extract_first(value):
-        """Extract first element from list, or return value if not a list."""
-        if isinstance(value, list) and len(value) > 0:
-            return value[0]
-        return value
 
     for dataflow in raw_dataflows:
         # Extract id (database_id)
@@ -468,168 +659,26 @@ def imf_dataset(
         database header, and whose second item is the pandas DataFrame. If
         return_raw == True, returns the raw JSON fetched from the API endpoint.
     """
-    import re
+    start_period = _normalize_year_arg(start_year, "start_year")
+    end_period = _normalize_year_arg(end_year, "end_year")
 
-    # Normalize start_year and end_year to strings
-    start_period = None
-    end_period = None
-
-    if start_year is not None:
-        try:
-            start_year = str(start_year)
-            if start_year.isdigit() and len(start_year) == 4:
-                start_period = start_year
-            else:
-                raise ValueError(
-                    "start_year must be a four-digit number, "
-                    "either integer or string."
-                )
-        except Exception:
-            raise ValueError(
-                "start_year must be a four-digit number, either integer or string."
-            )
-
-    if end_year is not None:
-        try:
-            end_year = str(end_year)
-            if end_year.isdigit() and len(end_year) == 4:
-                end_period = end_year
-            else:
-                raise ValueError(
-                    "end_year must be a four-digit number, either integer or string"
-                )
-        except Exception:
-            raise ValueError(
-                "end_year must be a four-digit number, either integer or string"
-            )
-
-    # Get available parameters for validation
     data_dimensions = imf_parameters(database_id, times)
-
-    # Helper to coerce legacy input parameter names to dataset-specific keys
-    def _coerce_input_keys_for_dataset(
-        input_dict: dict, available_keys: set[str]
-    ) -> dict:
-        def map_key(k: str) -> str:
-            kl = k.lower()
-            if kl in available_keys:
-                return kl
-            # Frequency aliases
-            if kl in ("freq", "frequency"):
-                for cand in ("frequency", "freq"):
-                    if cand in available_keys:
-                        if cand != kl:
-                            warn(
-                                f"Coercing parameter '{k}' to '{cand}' for this dataset"
-                            )
-                        return cand
-            # ref_area aliases
-            if kl in ("ref_area", "refarea", "ref-area", "country", "geo"):
-                for cand in ("ref_area", "refarea", "ref-area", "country", "geo"):
-                    if cand in available_keys:
-                        if cand != kl:
-                            warn(
-                                f"Coercing parameter '{k}' to '{cand}' for this dataset"
-                            )
-                        return cand
-            return kl
-
-        coerced: dict = {}
-        for k, v in input_dict.items():
-            new_k = map_key(k)
-            if new_k in coerced and new_k != k:
-                warn(
-                    f"Duplicate values for '{new_k}' after coercion; keeping the first"
-                )
-                continue
-            coerced[new_k] = v
-        return coerced
+    available_keys = set(data_dimensions.keys())
 
     if parameters is not None:
-        # Coerce legacy keys in provided parameters dict
-        parameters = _coerce_input_keys_for_dataset(
-            parameters, set(data_dimensions.keys())
-        )
+        parameters = _coerce_input_keys_for_dataset(parameters, available_keys)
         if kwargs:
             warn(
                 "Parameters list argument cannot be combined with character "
                 "vector parameters arguments. Character vector parameters "
                 "arguments will be ignored."
             )
-        for key in parameters:
-            if key not in data_dimensions:
-                raise ValueError(
-                    f"{key} not valid parameter(s) for the "
-                    f"{database_id} database. Use "
-                    f"imf_parameters('{database_id}') to get "
-                    "valid parameters."
-                )
-            invalid_keys = []
-            for x in list(parameters[key]["input_code"]):
-                if x not in list(data_dimensions[key]["input_code"]):
-                    invalid_keys.append(x)
-            if len(invalid_keys) > 0:
-                warn(
-                    f"{invalid_keys} not valid value(s) for {key} and will "
-                    f"be ignored. Use imf_parameters('{database_id}') to get "
-                    "valid parameters."
-                )
-            if (
-                set(parameters[key]["input_code"])
-                == set(data_dimensions[key]["input_code"])
-                or len(parameters[key]) == 0
-            ):
-                data_dimensions[key] = data_dimensions[key].iloc[0:0]
-            data_dimensions[key] = data_dimensions[key].iloc[
-                [
-                    index
-                    for index, x in enumerate(data_dimensions[key]["input_code"])
-                    if x in list(parameters[key]["input_code"])
-                ]
-            ]
-        for key in data_dimensions:
-            if key not in parameters:
-                data_dimensions[key] = data_dimensions[key].iloc[0:0]
-
+        _apply_selected_codes(
+            data_dimensions, _codes_from_parameters(parameters), database_id
+        )
     elif kwargs:
-        # Coerce legacy keys in kwargs
-        kwargs = _coerce_input_keys_for_dataset(kwargs, set(data_dimensions.keys()))
-        for key in kwargs:
-            if key not in data_dimensions:
-                raise ValueError(
-                    f"{key} not valid parameter(s) for the "
-                    f"{database_id} database. Use "
-                    f"imf_parameters('{database_id}') to get "
-                    "valid parameters."
-                )
-            invalid_vals = []
-            if not isinstance(kwargs[key], list):
-                kwargs[key] = [kwargs[key]]
-            for x in kwargs[key]:
-                if x not in data_dimensions[key]["input_code"].tolist():
-                    invalid_vals.append(x)
-            if len(invalid_vals) > 0:
-                warn(
-                    f"{invalid_vals} not valid value(s) for {key} and will "
-                    f"be ignored. Use imf_parameters('{database_id}') to get "
-                    "valid parameters."
-                )
-            if (
-                set(kwargs[key]) == set(data_dimensions[key]["input_code"].tolist())
-                or len(kwargs[key]) == 0
-            ):
-                data_dimensions[key] = data_dimensions[key].iloc[0:0]
-            data_dimensions[key] = data_dimensions[key].iloc[
-                [
-                    index
-                    for index, x in enumerate(data_dimensions[key]["input_code"])
-                    if x in kwargs[key]
-                ]
-            ]
-        for key in data_dimensions:
-            if key not in kwargs:
-                data_dimensions[key] = data_dimensions[key].iloc[0:0]
-
+        kwargs = _coerce_input_keys_for_dataset(kwargs, available_keys)
+        _apply_selected_codes(data_dimensions, _codes_from_kwargs(kwargs), database_id)
     else:
         print(
             "User supplied no filter parameters for the API request. "
@@ -638,151 +687,25 @@ def imf_dataset(
         for key in data_dimensions:
             data_dimensions[key] = data_dimensions[key].iloc[0:0]
 
-    # Normalize dimension filters (build dict mapping dimension names to code lists)
-    norm_dims = {}
-    for key in data_dimensions:
-        codes = data_dimensions[key]["input_code"].tolist()
-        if codes:
-            norm_dims[key.upper()] = codes
+    norm_dims = _normalized_dimension_filters(data_dimensions)
 
-    # Fetch DSD components to get dimension order
-    components = _get_datastructure_components(database_id, times)
-    dims = components.get("dimensionList", {}).get("dimensions", [])
-    time_dims = components.get("dimensionList", {}).get("timeDimensions", [])
+    # One dataflow lookup serves both DSD resolution and provider agency.
+    flow_row = _find_dataflow(database_id, times=times)
+    components = _get_datastructure_components(
+        database_id, times=times, flow_row=flow_row
+    )
+    key_rows = _series_key_rows(components)
+    key = _build_series_key(key_rows, norm_dims)
 
-    # Build list of all dimensions with position
-    all_dim_rows = []
-    for dim in dims:
-        if dim:
-            dim_id = _extract_first(dim.get("id"))
-            position = dim.get("position")
-            dim_type = _extract_first(dim.get("type"))
-            if dim_id and position is not None:
-                all_dim_rows.append(
-                    {
-                        "id": dim_id.upper(),
-                        "position": int(position),
-                        "type": dim_type,
-                    }
-                )
-
-    if time_dims:
-        for dim in time_dims:
-            if dim:
-                dim_id = _extract_first(dim.get("id"))
-                position = dim.get("position")
-                dim_type = _extract_first(dim.get("type"))
-                if dim_id and position is not None:
-                    all_dim_rows.append(
-                        {
-                            "id": dim_id.upper(),
-                            "position": int(position),
-                            "type": dim_type,
-                        }
-                    )
-
-    # Series key uses non-time dimensions (TIME_PERIOD varies at observation)
-    key_rows = [row for row in all_dim_rows if row["type"] != "TimeDimension"]
-    key_rows.sort(key=lambda x: x["position"])
-
-    # Validate requested dimension names exist
-    requested_dims = set(norm_dims.keys())
     available_dims = {row["id"] for row in key_rows}
-    unknown = requested_dims - available_dims
-    if unknown:
-        raise ValueError(
-            f"Unknown dimension(s): {', '.join(sorted(unknown))}. "
-            f"Available dimensions: {', '.join(sorted(available_dims))}"
-        )
-
-    # Build dot-separated key with plus-separated codes per position
-    segments = []
-    for row in key_rows:
-        dim_id = row["id"]
-        vals = norm_dims.get(dim_id, [])
-        if not vals:
-            segments.append("*")
-        else:
-            segments.append("+".join(vals))
-
-    key = ".".join(segments)
-
-    # Helper to transform time periods for API compatibility
-    def transform_period_for_frequency(period, frequency):
-        if not period:
-            return period
-
-        # Check if already in SDMX format with frequency suffix
-        if re.match(r"^\d{4}-(M|Q|A|W)\d+$", period):
-            return period
-
-        # User-friendly month format: "2019-01" to "2019-12"
-        if re.match(r"^\d{4}-\d{2}$", period):
-            parts = period.split("-")
-            return f"{parts[0]}-M{parts[1]}"
-
-        # Plain year (e.g., "2015") needs frequency-specific suffix
-        if re.match(r"^\d{4}$", period):
-            if frequency and len(frequency) == 1:
-                freq_map = {"A": "-A1", "Q": "-Q1", "M": "-M01", "W": "-W01"}
-                suffix = freq_map.get(frequency[0].upper(), "-A1")
-            else:
-                suffix = "-A1"  # default when frequency is wildcarded
-            return f"{period}{suffix}"
-
-        return period
-
-    # Extract frequency from user's dimension filter (if provided), dynamically resolving the dimension id
-    freq_dim_candidates = ["FREQUENCY", "FREQ"]
-    freq_dim_id = next((d for d in freq_dim_candidates if d in available_dims), None)
+    freq_dim_id = next((d for d in ("FREQUENCY", "FREQ") if d in available_dims), None)
     user_frequency = norm_dims.get(freq_dim_id) if freq_dim_id else None
+    provider_agency = _extract_first(flow_row.get("agencyID")) or "all"
+    query_params = _build_time_query_params(
+        start_period, end_period, user_frequency, provider_agency
+    )
 
-    # Build query params
-    query_params = {
-        "dimensionAtObservation": "TIME_PERIOD",
-        "attributes": "dsd",
-        "measures": "all",
-    }
-
-    # Apply time filters
-    time_filters = []
-    if start_period:
-        transformed_start = transform_period_for_frequency(start_period, user_frequency)
-        time_filters.append(f"ge:{transformed_start}")
-    if end_period:
-        transformed_end = transform_period_for_frequency(end_period, user_frequency)
-        time_filters.append(f"le:{transformed_end}")
-
-    # Determine dataflow agency (owner)
-    raw_dl = _download_parse("structure/dataflow/all/*/+", times=times)
-    raw_dataflows = raw_dl.get("data", {}).get("dataflows", [])
-    flow_row = None
-    for flow in raw_dataflows:
-        flow_id = _extract_first(flow.get("id"))
-        if flow_id == database_id:
-            flow_row = flow
-            break
-
-    if flow_row is None:
-        raise ValueError(f"Dataflow not found or not unique: {database_id}.")
-
-    provider_agency = _extract_first(flow_row.get("agencyID"))
-    if not provider_agency:
-        provider_agency = "all"
-
-    # Apply time filter only for IMF.STA via c[TIME_PERIOD]
-    if time_filters:
-        if provider_agency == "IMF.STA":
-            query_params["c[TIME_PERIOD]"] = "+".join(time_filters)
-        else:
-            warn(
-                f"Agency {provider_agency} does not support time filters; "
-                "time window will be ignored."
-            )
-
-    # Build path and perform request
     data_path = f"data/dataflow/{provider_agency}/{database_id}/+/{key}"
-
     if print_url:
         full_url = f"{IMF_API_BASE_URL.rstrip('/')}/{data_path}"
         if query_params:
@@ -793,26 +716,19 @@ def imf_dataset(
 
     if return_raw:
         if include_metadata:
-            # For now, return empty metadata dict (could be enhanced later)
-            metadata = {}
+            metadata: dict = {}
             return metadata, message
-        else:
-            return message
+        return message
 
-    # Parse SDMX JSON message into DataFrame
     result = _parse_imf_sdmx_json(message)
-
     if result.empty:
         raise ValueError(
             "No data found for that combination of parameters. "
             "Try making your request less restrictive."
         )
 
-    # Convert column names to lowercase for backward compatibility
     result.columns = result.columns.str.lower()
-
-    if not include_metadata:
-        return result
-    else:
-        metadata = {}  # Could be enhanced to extract from message later
+    if include_metadata:
+        metadata = {}
         return metadata, result
+    return result

--- a/imfp/data.py
+++ b/imfp/data.py
@@ -365,13 +365,12 @@ def imf_dataset(
     parameters: dict | None = None,
     start_year: int | str | None = None,
     end_year: int | str | None = None,
-    return_raw: bool = False,
+    return_raw: Literal[False] = False,
     print_url: bool = False,
     times: int = 3,
     include_metadata: Literal[False] = False,
     **kwargs,
-) -> DataFrame:
-    ...
+) -> DataFrame: ...
 
 
 @overload
@@ -380,13 +379,40 @@ def imf_dataset(
     parameters: dict | None = None,
     start_year: int | str | None = None,
     end_year: int | str | None = None,
-    return_raw: bool = False,
+    return_raw: Literal[False] = False,
     print_url: bool = False,
     times: int = 3,
     include_metadata: Literal[True] = True,
     **kwargs,
-) -> tuple[dict, DataFrame]:
-    ...
+) -> tuple[dict, DataFrame]: ...
+
+
+@overload
+def imf_dataset(
+    database_id: str,
+    parameters: dict | None = None,
+    start_year: int | str | None = None,
+    end_year: int | str | None = None,
+    return_raw: Literal[True] = True,
+    print_url: bool = False,
+    times: int = 3,
+    include_metadata: Literal[False] = False,
+    **kwargs,
+) -> dict: ...
+
+
+@overload
+def imf_dataset(
+    database_id: str,
+    parameters: dict | None = None,
+    start_year: int | str | None = None,
+    end_year: int | str | None = None,
+    return_raw: Literal[True] = True,
+    print_url: bool = False,
+    times: int = 3,
+    include_metadata: Literal[True] = True,
+    **kwargs,
+) -> tuple[dict, dict]: ...
 
 
 @type_enforced.Enforcer
@@ -400,7 +426,7 @@ def imf_dataset(
     times: int = 3,
     include_metadata: bool = False,
     **kwargs,
-) -> DataFrame | tuple[dict, DataFrame]:
+) -> DataFrame | dict | tuple[dict, DataFrame | dict]:
     """
     Download a data series from the IMF.
 

--- a/imfp/data.py
+++ b/imfp/data.py
@@ -601,7 +601,8 @@ def imf_dataset(
     times: int = 3,
     include_metadata: Literal[False] = False,
     **kwargs: Any,
-) -> DataFrame: ...
+) -> DataFrame:
+    ...
 
 
 @overload
@@ -615,7 +616,8 @@ def imf_dataset(
     times: int = 3,
     include_metadata: Literal[True] = True,
     **kwargs: Any,
-) -> tuple[dict[str, Any], DataFrame]: ...
+) -> tuple[dict[str, Any], DataFrame]:
+    ...
 
 
 @overload
@@ -629,7 +631,8 @@ def imf_dataset(
     times: int = 3,
     include_metadata: Literal[False] = False,
     **kwargs: Any,
-) -> dict[str, Any]: ...
+) -> dict[str, Any]:
+    ...
 
 
 @overload
@@ -643,7 +646,8 @@ def imf_dataset(
     times: int = 3,
     include_metadata: Literal[True] = True,
     **kwargs: Any,
-) -> tuple[dict[str, Any], dict[str, Any]]: ...
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    ...
 
 
 @type_enforced.Enforcer

--- a/imfp/utils.py
+++ b/imfp/utils.py
@@ -400,12 +400,38 @@ def _parse_codelist_urn(urn: str) -> dict[str, Optional[str]]:
     }
 
 
-def _get_datastructure_components(dataflow_id: str, times: int = 3) -> dict:
+def _find_dataflow(dataflow_id: str, times: int = 3) -> dict:
+    """
+    (Internal) Look up a dataflow object by ID from the IMF dataflow catalog.
+
+    Args:
+        dataflow_id (str): The ID of the dataflow (database_id).
+        times (int, optional): The number of times to retry the request.
+            Defaults to 3.
+
+    Returns:
+        dict: The matching dataflow object from the API response.
+    """
+    raw_dl = _download_parse("structure/dataflow/all/*/+", times=times)
+    raw_dataflows = raw_dl.get("data", {}).get("dataflows")
+    if raw_dataflows is None:
+        raise ValueError("No dataflows found in API response.")
+
+    for flow in raw_dataflows:
+        if _extract_first(flow.get("id")) == dataflow_id:
+            return flow
+
+    raise ValueError(f"Dataflow not found or not unique: {dataflow_id}.")
+
+
+def _get_datastructure_components(
+    dataflow_id: str, times: int = 3, flow_row: Optional[dict] = None
+) -> dict:
     """
     (Internal) Retrieve raw datastructure components for a dataflow.
 
     This function:
-    1. Gets the dataflow to find its structure URN
+    1. Gets the dataflow to find its structure URN (or uses a provided flow)
     2. Parses the structure URN to get agency and ID
     3. Fetches the DSD (datastructure definition)
     4. Returns the dataStructureComponents
@@ -414,41 +440,29 @@ def _get_datastructure_components(dataflow_id: str, times: int = 3) -> dict:
         dataflow_id (str): The ID of the dataflow (database_id).
         times (int, optional): The number of times to retry the request.
             Defaults to 3.
+        flow_row (dict, optional): Pre-fetched dataflow object. When provided,
+            skips the dataflow catalog request.
 
     Returns:
         dict: The dataStructureComponents dictionary containing dimensionList,
             measureList, etc.
     """
-    # Step 1: Get dataflow to find its structure URN
-    raw_dl = _download_parse("structure/dataflow/all/*/+", times=times)
-    raw_dataflows = raw_dl.get("data", {}).get("dataflows")
-    if raw_dataflows is None:
-        raise ValueError("No dataflows found in API response.")
-
-    # Find the matching dataflow
-    flow_row = None
-    for flow in raw_dataflows:
-        flow_id = _extract_first(flow.get("id"))
-        if flow_id == dataflow_id:
-            flow_row = flow
-            break
-
     if flow_row is None:
-        raise ValueError(f"Dataflow not found or not unique: {dataflow_id}.")
+        flow_row = _find_dataflow(dataflow_id, times=times)
 
     # Extract structure URN
     structure_urn = _extract_first(flow_row.get("structure"))
     if not structure_urn:
         raise ValueError(f"Invalid structure URN for dataflow {dataflow_id}.")
 
-    # Step 2: Parse structure URN
+    # Parse structure URN
     dsd_ref = _parse_datastructure_urn(structure_urn)
     if not dsd_ref.get("agency") or not dsd_ref.get("id"):
         raise ValueError(
             f"Invalid structure URN for dataflow {dataflow_id}: {structure_urn}"
         )
 
-    # Step 3: Fetch DSD
+    # Fetch DSD
     dsd_path = f"structure/datastructure/{dsd_ref['agency']}/{dsd_ref['id']}/+"
     dsd_body = _download_parse(dsd_path, times=times)
 
@@ -456,7 +470,6 @@ def _get_datastructure_components(dataflow_id: str, times: int = 3) -> dict:
     if not dsds or len(dsds) < 1:
         raise ValueError(f"No dataStructures found in DSD response for {dataflow_id}.")
 
-    # Step 4: Extract components
     components = dsds[0].get("dataStructureComponents")
     if components is None:
         raise ValueError(f"No dataStructureComponents found in DSD for {dataflow_id}.")
@@ -718,22 +731,12 @@ def _imf_metadata(database_id, times=3):
     if not database_id:
         raise ValueError("Must supply database_id.")
 
-    # Get all dataflows to find the matching one
-    raw_dl = _download_parse("structure/dataflow/all/*/+", times=times)
-    raw_dataflows = raw_dl.get("data", {}).get("dataflows")
-    if raw_dataflows is None:
-        raise ValueError("No dataflows found in API response.")
-
-    # Find the matching dataflow
-    flow_row = None
-    for flow in raw_dataflows:
-        flow_id = _extract_first(flow.get("id"))
-        if flow_id == database_id:
-            flow_row = flow
-            break
-
-    if flow_row is None:
-        raise ValueError(f"Dataflow not found: {database_id}.")
+    try:
+        flow_row = _find_dataflow(database_id, times=times)
+    except ValueError as e:
+        if "Dataflow not found" in str(e):
+            raise ValueError(f"Dataflow not found: {database_id}.") from e
+        raise
 
     # Extract agency ID and version for detailed metadata query
     agency_id = _extract_first(flow_row.get("agencyID"))

--- a/tests/test_imf_dataset_processes.py
+++ b/tests/test_imf_dataset_processes.py
@@ -20,7 +20,11 @@ import pytest
 import responses
 
 from imfp import imf_dataset, imf_parameters, set_imf_wait_time
-from imfp.data import _parse_imf_sdmx_json
+from imfp.data import (
+    _normalize_year_arg,
+    _parse_imf_sdmx_json,
+    _transform_period_for_frequency,
+)
 from imfp.utils import _imf_save_response, _imf_use_cache
 
 wait_time = 0
@@ -249,6 +253,32 @@ def test_parse_imf_sdmx_json_performance_large_message():
     # Generous ceiling: current implementation is well under this on CI/dev CPUs.
     # The goal is to catch pathological regressions (e.g. accidental O(n^2) copies).
     assert elapsed < 2.0, f"parse took {elapsed:.3f}s for {len(df)} rows"
+
+
+# ---------------------------------------------------------------------------
+# Year / period helpers extracted from imf_dataset
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_year_arg_accepts_int_and_str():
+    assert _normalize_year_arg(None, "start_year") is None
+    assert _normalize_year_arg(2010, "start_year") == "2010"
+    assert _normalize_year_arg("2010", "end_year") == "2010"
+    with pytest.raises(ValueError, match="start_year must be a four-digit"):
+        _normalize_year_arg(10, "start_year")
+    with pytest.raises(ValueError, match="end_year must be a four-digit"):
+        _normalize_year_arg("abcd", "end_year")
+
+
+def test_transform_period_for_frequency_variants():
+    assert _transform_period_for_frequency(None, ["A"]) is None
+    assert _transform_period_for_frequency("2019-M01", ["M"]) == "2019-M01"
+    assert _transform_period_for_frequency("2019-01", ["M"]) == "2019-M01"
+    assert _transform_period_for_frequency("2015", ["A"]) == "2015-A1"
+    assert _transform_period_for_frequency("2015", ["Q"]) == "2015-Q1"
+    assert _transform_period_for_frequency("2015", ["M"]) == "2015-M01"
+    assert _transform_period_for_frequency("2015", None) == "2015-A1"
+    assert _transform_period_for_frequency("2015", ["A", "Q"]) == "2015-A1"
 
 
 # ---------------------------------------------------------------------------
@@ -515,10 +545,11 @@ def test_imf_dataset_request_count_ceiling(set_options):
         rsps.stop()
         rsps.reset()
 
-    # Observed baseline: 15 total requests / 3 dataflow list fetches / 8 unique URLs
-    assert len(urls) <= 15
+    # Baseline after sharing one dataflow lookup for DSD + agency resolution.
+    # imf_parameters() still performs its own catalog/DSD fetches upstream.
+    assert len(urls) <= 14
     dataflow_list_fetches = sum(
         1 for u in urls if "structure/dataflow/all/" in u and "/data/" not in u
     )
-    assert dataflow_list_fetches <= 3
+    assert dataflow_list_fetches <= 2
     assert len(_data_request_urls(urls)) == 1

--- a/tests/test_imf_dataset_processes.py
+++ b/tests/test_imf_dataset_processes.py
@@ -1,0 +1,524 @@
+"""Regression tests for imf_dataset subprocesses.
+
+These guard correctness and performance of the pieces that issue #68 will
+simplify/modularize (parameter coercion/filtering, series-key construction,
+period transforms, SDMX JSON parsing, and request orchestration).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pandas as pd
+import pytest
+import responses
+
+from imfp import imf_dataset, imf_parameters, set_imf_wait_time
+from imfp.data import _parse_imf_sdmx_json
+from imfp.utils import _imf_save_response, _imf_use_cache
+
+wait_time = 0
+
+
+@pytest.fixture
+def set_options(monkeypatch):
+    os.makedirs("tests/responses", exist_ok=True)
+    original_save_response = _imf_save_response
+    original_use_cache = _imf_use_cache
+    original_wait_time = os.environ.get("IMF_WAIT_TIME", None)
+
+    monkeypatch.setattr("imfp.utils._imf_save_response", False)
+    monkeypatch.setattr("imfp.utils._imf_use_cache", False)
+    set_imf_wait_time(wait_time)
+
+    yield
+
+    monkeypatch.setattr("imfp.utils._imf_save_response", original_save_response)
+    monkeypatch.setattr("imfp.utils._imf_use_cache", original_use_cache)
+    if original_wait_time is not None:
+        os.environ["IMF_WAIT_TIME"] = original_wait_time
+    else:
+        os.environ.pop("IMF_WAIT_TIME", None)
+
+
+def _synthetic_sdmx_message(
+    *,
+    series: dict | None = None,
+    series_dims: list[dict] | None = None,
+    obs_dim_values: list[dict] | None = None,
+    include_data: bool = True,
+    include_datasets: bool = True,
+    include_structures: bool = True,
+) -> dict:
+    """Build a minimal SDMX 3.0 JSON message for parser unit tests."""
+    if series_dims is None:
+        series_dims = [
+            {
+                "id": "COUNTRY",
+                "values": [{"id": "US"}, {"id": "CA"}],
+            },
+            {
+                "id": "INDICATOR",
+                "values": [{"id": "NGDP_RPCH"}],
+            },
+            {
+                "id": "FREQUENCY",
+                "values": [{"id": "A"}],
+            },
+        ]
+    if obs_dim_values is None:
+        obs_dim_values = [{"value": "2020"}, {"value": "2021"}, {"value": "2022"}]
+    if series is None:
+        series = {
+            "0:0:0": {
+                "observations": {
+                    "0": ["1.5"],
+                    "1": ["NA"],
+                    "2": ["2.25"],
+                }
+            },
+            "1:0:0": {
+                "observations": {
+                    "0": ["3.0"],
+                    "1": ["NP"],
+                }
+            },
+        }
+
+    message: dict = {}
+    if not include_data:
+        return message
+
+    data: dict = {}
+    if include_datasets:
+        data["dataSets"] = [{"series": series}]
+    if include_structures:
+        data["structures"] = [
+            {
+                "dimensions": {
+                    "series": series_dims,
+                    "observation": [{"id": "TIME_PERIOD", "values": obs_dim_values}],
+                }
+            }
+        ]
+    message["data"] = data
+    return message
+
+
+def _capture_requests():
+    """Return a responses mock that replays cached fixtures and records URLs."""
+    urls: list[str] = []
+
+    def responder(request):
+        urls.append(request.url)
+        file_name = hashlib.sha256(request.url.encode()).hexdigest()
+        file_path = Path("tests/responses") / f"{file_name}.json"
+        if not file_path.exists():
+            raise AssertionError(
+                f"No cached HTTP fixture for URL: {request.url}\n"
+                f"Expected file: {file_path}"
+            )
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        status = int(data.get("status_code", 200))
+        body = data.get("text") or data.get("content") or ""
+        headers = dict(data.get("headers", {}))
+        for key in (
+            "content-encoding",
+            "Content-Encoding",
+            "content-length",
+            "Content-Length",
+        ):
+            headers.pop(key, None)
+        return (status, headers, body)
+
+    rsps = responses.RequestsMock(assert_all_requests_are_fired=False)
+    rsps.start()
+    rsps.add_callback(responses.GET, re.compile(r".*"), callback=responder)
+    return rsps, urls
+
+
+def _data_request_urls(urls: list[str]) -> list[str]:
+    return [u for u in urls if "/data/dataflow/" in u]
+
+
+# ---------------------------------------------------------------------------
+# SDMX JSON parsing (_parse_imf_sdmx_json)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_imf_sdmx_json_empty_and_missing_sections():
+    assert _parse_imf_sdmx_json({}).empty
+    assert _parse_imf_sdmx_json({"data": {}}).empty
+    assert _parse_imf_sdmx_json(_synthetic_sdmx_message(include_datasets=False)).empty
+    assert _parse_imf_sdmx_json(_synthetic_sdmx_message(include_structures=False)).empty
+    assert _parse_imf_sdmx_json(
+        _synthetic_sdmx_message(series={})
+    ).empty  # no series keys
+
+
+def test_parse_imf_sdmx_json_decodes_series_and_observations():
+    df = _parse_imf_sdmx_json(_synthetic_sdmx_message())
+
+    assert list(df.columns) == [
+        "COUNTRY",
+        "INDICATOR",
+        "FREQUENCY",
+        "TIME_PERIOD",
+        "OBS_VALUE",
+    ]
+    assert len(df) == 5
+    assert set(df["COUNTRY"]) == {"US", "CA"}
+    assert set(df["INDICATOR"]) == {"NGDP_RPCH"}
+    assert set(df["FREQUENCY"]) == {"A"}
+
+    us = df[df["COUNTRY"] == "US"].sort_values("TIME_PERIOD")
+    assert us["TIME_PERIOD"].tolist() == ["2020", "2021", "2022"]
+    assert us["OBS_VALUE"].tolist()[0] == pytest.approx(1.5)
+    assert pd.isna(us["OBS_VALUE"].tolist()[1])  # "NA" -> None
+    assert us["OBS_VALUE"].tolist()[2] == pytest.approx(2.25)
+
+    ca = df[df["COUNTRY"] == "CA"]
+    assert pd.isna(ca.loc[ca["TIME_PERIOD"] == "2021", "OBS_VALUE"].iloc[0])  # "NP"
+
+
+def test_parse_imf_sdmx_json_skips_series_without_observations():
+    message = _synthetic_sdmx_message(
+        series={
+            "0:0:0": {"observations": {}},
+            "1:0:0": {"observations": {"0": ["4.0"]}},
+        }
+    )
+    df = _parse_imf_sdmx_json(message)
+    assert len(df) == 1
+    assert df.iloc[0]["COUNTRY"] == "CA"
+    assert df.iloc[0]["OBS_VALUE"] == pytest.approx(4.0)
+
+
+def test_parse_imf_sdmx_json_maps_common_missing_value_flags():
+    message = _synthetic_sdmx_message(
+        series={
+            "0:0:0": {
+                "observations": {
+                    "0": ["ND"],
+                    "1": ["N/A"],
+                    "2": ["not-a-number"],
+                }
+            }
+        }
+    )
+    df = _parse_imf_sdmx_json(message)
+    # ND and N/A map to None; other non-numeric strings also become None via float() fail
+    assert df["OBS_VALUE"].isna().all()
+
+
+def test_parse_imf_sdmx_json_performance_large_message():
+    """Parsing should stay linear-ish: large synthetic payload finishes quickly."""
+    n_series = 200
+    n_obs = 120
+    series_dims = [
+        {"id": "COUNTRY", "values": [{"id": f"C{i:03d}"} for i in range(n_series)]},
+        {"id": "INDICATOR", "values": [{"id": "X"}]},
+        {"id": "FREQUENCY", "values": [{"id": "A"}]},
+    ]
+    obs_values = [{"value": str(2000 + i)} for i in range(n_obs)]
+    series = {
+        f"{i}:0:0": {
+            "observations": {str(j): [str(float(i + j))] for j in range(n_obs)}
+        }
+        for i in range(n_series)
+    }
+    message = _synthetic_sdmx_message(
+        series=series, series_dims=series_dims, obs_dim_values=obs_values
+    )
+
+    # Warm once so import/pandas setup is not charged against the budget.
+    _parse_imf_sdmx_json(message)
+
+    start = time.perf_counter()
+    df = _parse_imf_sdmx_json(message)
+    elapsed = time.perf_counter() - start
+
+    assert len(df) == n_series * n_obs
+    # Generous ceiling: current implementation is well under this on CI/dev CPUs.
+    # The goal is to catch pathological regressions (e.g. accidental O(n^2) copies).
+    assert elapsed < 2.0, f"parse took {elapsed:.3f}s for {len(df)} rows"
+
+
+# ---------------------------------------------------------------------------
+# Parameter coercion, filtering, and request construction
+# ---------------------------------------------------------------------------
+
+
+def test_imf_dataset_parameters_dict_matches_kwargs(set_options):
+    """parameters= and **kwargs filtering should produce identical series keys."""
+    rsps, urls = _capture_requests()
+    try:
+        params = imf_parameters("GFS_SOO", times=1)
+        for key in list(params):
+            if key == "country":
+                params[key] = params[key][params[key]["input_code"] == "ABW"]
+            elif key == "sector":
+                params[key] = params[key][params[key]["input_code"] == "S13"]
+            elif key == "gfs_grp":
+                params[key] = params[key][params[key]["input_code"] == "G2M"]
+            elif key == "indicator":
+                params[key] = params[key][params[key]["input_code"] == "G23_T"]
+            elif key == "type_of_transformation":
+                params[key] = params[key][params[key]["input_code"] == "POGDP_PT"]
+            elif key in ("freq", "frequency"):
+                params[key] = params[key][params[key]["input_code"] == "A"]
+            else:
+                params[key] = params[key].iloc[0:0]
+
+        urls.clear()
+        df_params = imf_dataset(
+            database_id="GFS_SOO",
+            parameters=params,
+            start_year=1972,
+            end_year=1976,
+            times=1,
+        )
+        params_urls = list(_data_request_urls(urls))
+        urls.clear()
+
+        with pytest.warns(UserWarning, match="Coercing parameter 'freq'"):
+            df_kwargs = imf_dataset(
+                database_id="GFS_SOO",
+                country="ABW",
+                sector="S13",
+                gfs_grp="G2M",
+                indicator=["G23_T"],
+                type_of_transformation="POGDP_PT",
+                freq="A",
+                start_year=1972,
+                end_year=1976,
+                times=1,
+            )
+        kwargs_urls = list(_data_request_urls(urls))
+    finally:
+        rsps.stop()
+        rsps.reset()
+
+    assert len(params_urls) == 1 and len(kwargs_urls) == 1
+    assert params_urls[0] == kwargs_urls[0]
+    pd.testing.assert_frame_equal(
+        df_params.sort_values(list(df_params.columns)).reset_index(drop=True),
+        df_kwargs.sort_values(list(df_kwargs.columns)).reset_index(drop=True),
+    )
+
+
+def test_imf_dataset_builds_series_key_and_time_filter_for_imf_sta(set_options):
+    rsps, urls = _capture_requests()
+    try:
+        with pytest.warns(UserWarning, match="Coercing parameter 'freq'"):
+            df = imf_dataset(
+                database_id="GFS_SOO",
+                country="ABW",
+                sector="S13",
+                gfs_grp="G2M",
+                indicator=["G23_T"],
+                type_of_transformation="POGDP_PT",
+                freq="A",
+                start_year=1972,
+                end_year=1976,
+                times=1,
+            )
+    finally:
+        rsps.stop()
+        rsps.reset()
+
+    assert len(df) > 0
+    data_urls = _data_request_urls(urls)
+    assert len(data_urls) == 1
+    parsed = urlparse(data_urls[0])
+    # Path ends with .../GFS_SOO/+/ABW.S13.G2M.G23_T.POGDP_PT.A
+    assert parsed.path.endswith("/GFS_SOO/+/ABW.S13.G2M.G23_T.POGDP_PT.A")
+    qs = parse_qs(parsed.query)
+    assert qs["dimensionAtObservation"] == ["TIME_PERIOD"]
+    assert qs["attributes"] == ["dsd"]
+    assert qs["measures"] == ["all"]
+    assert qs["c[TIME_PERIOD]"] == ["ge:1972-A1+le:1976-A1"]
+
+
+def test_imf_dataset_ignores_time_filters_for_non_sta_agency(set_options):
+    rsps, urls = _capture_requests()
+    try:
+        with pytest.warns(UserWarning, match="does not support time filters"):
+            imf_dataset(
+                database_id="WHDREO",
+                freq="A",
+                country="GX1213",
+                indicator=["BCA_GDP_BP6"],
+                start_year=2010,
+                end_year=2012,
+                times=1,
+            )
+    finally:
+        rsps.stop()
+        rsps.reset()
+
+    data_urls = _data_request_urls(urls)
+    assert len(data_urls) == 1
+    qs = parse_qs(urlparse(data_urls[0]).query)
+    assert "c[TIME_PERIOD]" not in qs
+    assert urlparse(data_urls[0]).path.endswith("/WHDREO/+/GX1213.BCA_GDP_BP6.A")
+
+
+def test_imf_dataset_coerces_freq_alias(set_options):
+    rsps, urls = _capture_requests()
+    try:
+        with pytest.warns(UserWarning, match="Coercing parameter 'freq'"):
+            imf_dataset(
+                database_id="WHDREO",
+                freq="A",
+                country="GX1213",
+                indicator=["BCA_GDP_BP6"],
+                times=1,
+            )
+    finally:
+        rsps.stop()
+        rsps.reset()
+
+    data_urls = _data_request_urls(urls)
+    assert urlparse(data_urls[0]).path.endswith("/GX1213.BCA_GDP_BP6.A")
+
+
+def test_imf_dataset_return_raw_and_print_url(set_options, capsys):
+    rsps, urls = _capture_requests()
+    try:
+        with pytest.warns(UserWarning, match="Coercing parameter 'freq'"):
+            raw = imf_dataset(
+                database_id="WHDREO",
+                freq="A",
+                country="GX1213",
+                indicator=["BCA_GDP_BP6"],
+                return_raw=True,
+                print_url=True,
+                times=1,
+            )
+        with pytest.warns(UserWarning, match="Coercing parameter 'freq'"):
+            meta, raw_meta = imf_dataset(
+                database_id="WHDREO",
+                freq="A",
+                country="GX1213",
+                indicator=["BCA_GDP_BP6"],
+                return_raw=True,
+                include_metadata=True,
+                times=1,
+            )
+    finally:
+        rsps.stop()
+        rsps.reset()
+
+    assert isinstance(raw, dict)
+    assert "data" in raw
+    assert isinstance(meta, dict)
+    assert isinstance(raw_meta, dict)
+
+    printed = capsys.readouterr().out
+    assert "data/dataflow/" in printed
+    assert "WHDREO" in printed
+
+
+def test_imf_dataset_year_validation_accepts_int_and_str(set_options):
+    rsps, _ = _capture_requests()
+    try:
+        df_int = imf_dataset(
+            database_id="GFS_SOO",
+            country="ABW",
+            sector="S13",
+            gfs_grp="G2M",
+            indicator=["G23_T"],
+            type_of_transformation="POGDP_PT",
+            freq="A",
+            start_year=1972,
+            end_year=1976,
+            times=1,
+        )
+        df_str = imf_dataset(
+            database_id="GFS_SOO",
+            country="ABW",
+            sector="S13",
+            gfs_grp="G2M",
+            indicator=["G23_T"],
+            type_of_transformation="POGDP_PT",
+            freq="A",
+            start_year="1972",
+            end_year="1976",
+            times=1,
+        )
+    finally:
+        rsps.stop()
+        rsps.reset()
+
+    pd.testing.assert_frame_equal(
+        df_int.sort_values(list(df_int.columns)).reset_index(drop=True),
+        df_str.sort_values(list(df_str.columns)).reset_index(drop=True),
+    )
+
+
+def test_imf_dataset_no_filters_warns_and_wildcards(set_options, capsys):
+    # APDREO has a cached wildcard data fixture from error-handling tests.
+    rsps, urls = _capture_requests()
+    try:
+        # May raise if no data for full DB; we only care about the user message
+        # and that the series key is all wildcards when filters are omitted.
+        try:
+            imf_dataset(database_id="APDREO", times=1)
+        except ValueError as exc:
+            # Empty DB responses are acceptable for this path.
+            assert "No data found" in str(exc) or "combination of parameters" in str(
+                exc
+            )
+    finally:
+        rsps.stop()
+        rsps.reset()
+
+    out = capsys.readouterr().out
+    assert "User supplied no filter parameters" in out
+    data_urls = _data_request_urls(urls)
+    assert len(data_urls) == 1
+    # All non-time dimensions wildcarded
+    assert urlparse(data_urls[0]).path.endswith("/APDREO/+/*.*.*")
+
+
+# ---------------------------------------------------------------------------
+# Request-count / orchestration performance ceiling
+# ---------------------------------------------------------------------------
+
+
+def test_imf_dataset_request_count_ceiling(set_options):
+    """Guard against request amplification when orchestration is refactored.
+
+    Current WHDREO path issues duplicate dataflow lookups. Refactors may reduce
+    this count; they must not increase it.
+    """
+    rsps, urls = _capture_requests()
+    try:
+        imf_dataset(
+            database_id="WHDREO",
+            freq="A",
+            country="GX1213",
+            indicator=["BCA_GDP_BP6"],
+            start_year=2010,
+            end_year=2012,
+            times=1,
+        )
+    finally:
+        rsps.stop()
+        rsps.reset()
+
+    # Observed baseline: 15 total requests / 3 dataflow list fetches / 8 unique URLs
+    assert len(urls) <= 15
+    dataflow_list_fetches = sum(
+        1 for u in urls if "structure/dataflow/all/" in u and "/data/" not in u
+    )
+    assert dataflow_list_fetches <= 3
+    assert len(_data_request_urls(urls)) == 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add offline regression tests for the `imf_dataset` subprocesses targeted by issue #68: SDMX JSON parsing (including a large-payload performance ceiling), parameter coercion/filtering equivalence, series-key and time-filter URL construction, `return_raw`/`print_url`, year/period helpers, and request-count ceilings.
- Fix `imf_dataset` return type annotations so `return_raw=True` matches the documented `dict` return under `type_enforced`.
- Modularize `imf_dataset` by extracting helpers for year/period normalization, parameter alias coercion, dimension filtering, series-key construction, and time query params; deduplicate the `parameters=` vs `**kwargs` filter paths.
- Share a single dataflow catalog lookup for DSD resolution and provider agency (cuts duplicate fetches; WHDREO path now ≤14 requests / ≤2 catalog fetches).

## Test plan
- [x] `uv run pytest tests` (35 passed)
- [x] `uv run black --check imfp tests/test_imf_dataset_processes.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc0a5911-7b1d-4dc0-a7be-55f42acac516?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc0a5911-7b1d-4dc0-a7be-55f42acac516&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

