### PR TITLE
Refactor API to follow econdataverse conventions (v2.0.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,10 @@ Run everything through `uv run` (do not activate the venv manually). Key command
 - Tests: `uv run pytest tests` — fully offline. `tests/conftest.py` mocks HTTP by hashing
   request URLs (SHA256) and replaying cached JSON from `tests/responses/`, so no network
   or API key is needed.
-- Format check: `uv run black --check .` (CI's `format.yml` auto-formats on push via
-  action-black, so a local reformat finding is expected, not a setup failure).
-- Type check: `uv run mypy imfp` (config in `mypy.ini`).
+- Format: `uv run ruff format .` (or `--check` to verify; CI's `format.yml` auto-formats
+  on push, and `test.yml` runs the check on pull requests).
+- Lint: `uv run ruff check .` (config under `[tool.ruff]` in `pyproject.toml`).
+- Type check: `uv run ty check` (config under `[tool.ty.rules]` in `pyproject.toml`).
 - Build: `uv build` (wheel + sdist into `dist/`).
 - Docs: `uv run great-docs build` (output in `great-docs/_site/`; requires Quarto CLI and
   Python >= 3.11 for the `great-docs` dependency).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tests](https://github.com/Promptly-Technologies-LLC/imfp/actions/workflows/test.yml/badge.svg)](https://github.com/Promptly-Technologies-LLC/imfp/actions/workflows/test.yml)
 [![PyPI Version](https://img.shields.io/pypi/v/imfp.svg)](https://pypi.python.org/pypi/imfp)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-261230.svg)](https://github.com/astral-sh/ruff)
 
 `imfp`, by Christopher C. Smith, is a Python package for downloading data from the [International Monetary Fund's](http://data.imf.org/) RESTful JSON API.
 
@@ -16,27 +16,56 @@ pip install -q --upgrade imfp
 
 ## Quick Start
 
+`imfp` follows the [econdataverse](https://econdataverse.org/) conventions, mirroring the R package [imfapi](https://github.com/Teal-Insights/r-imfapi). Fetching data takes four steps, one per function:
+
 ```python
 import imfp
 
-# Get list of available databases
-databases = imfp.imf_databases()
+# 1. Find a dataset
+dataflows = imfp.imf_get_dataflows()
 
-# Get parameters for a specific database (e.g., PCPS - Primary Commodity Price System)
-params = imfp.imf_parameters("PCPS")
+# 2. See how it can be filtered
+dimensions = imfp.imf_get_datastructure("PCPS")
 
-# Fetch data with specific parameters
-df = imfp.imf_dataset(
-    database_id="PCPS", frequency=["A"], start_year=2000, end_year=2015
+# 3. Find valid codes for those dimensions
+codes = imfp.imf_get_codelists(["INDICATOR", "FREQUENCY"], "PCPS")
+
+# 4. Fetch the data
+df = imfp.imf_get(
+    "PCPS",
+    dimensions={
+        "INDICATOR": ["PCOAL"],
+        "DATA_TRANSFORMATION": ["INDEX"],
+        "FREQUENCY": ["A"],
+    },
 )
 ```
+
+Dimensions can also be passed as keyword arguments:
+
+```python
+df = imfp.imf_get("PCPS", indicator="PCOAL", data_transformation="INDEX", frequency="A")
+```
+
+## Upgrading from 1.x
+
+Version 2.0.0 replaces the old four-function API. The old names still work but emit a `DeprecationWarning`, and will be removed in 3.0.0.
+
+| imfp 1.x | imfp 2.0 |
+|---|---|
+| `imf_databases()` | `imf_get_dataflows()` |
+| `imf_parameters(db)` | `imf_get_codelists(dims, db)` |
+| `imf_parameter_defs(db)` | `imf_get_datastructure(db)` |
+| `imf_dataset(db, ...)` | `imf_get(db, ...)` |
+
+See the [migration guide](https://promptlytechnologies.com/imfp/user-guide/migration.html) for argument-by-argument details.
 
 ## Key Features
 
 - Comprehensive access to IMF's extensive economic databases
-- Parameter discovery
+- Dataset, dimension, and code discovery
+- Tidy `pandas` DataFrame output, with numeric observation values
 - Rate limit and bandwidth management
-- Returns data in pandas DataFrames
 
 ## Contributing
 

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -68,6 +68,7 @@ user_guide:
     contents:
       - usage.qmd
       - rate_limits.qmd
+      - migration.qmd
   - section: "Examples"
     contents:
       - demo.qmd
@@ -81,15 +82,29 @@ user_guide:
 # - Add 'desc:' to sections for descriptions
 
 reference:
-  - title: Functions
-    desc: Public functions for discovering IMF databases and downloading data
+  - title: Fetching Data
+    desc: >
+      The econdataverse-style workflow: discover a dataset, inspect how it can
+      be filtered, look up valid codes, then request observations.
+    contents:
+      - imf_get_dataflows
+      - imf_get_datastructure
+      - imf_get_codelists
+      - imf_get
+  - title: Configuration
+    desc: Settings that affect how requests are made
+    contents:
+      - set_imf_app_name
+      - set_imf_wait_time
+  - title: Deprecated
+    desc: >
+      The pre-2.0 interface. These still work but emit a DeprecationWarning and
+      will be removed in imfp 3.0.0. See the migration guide.
     contents:
       - imf_databases
       - imf_parameters
       - imf_parameter_defs
       - imf_dataset
-      - set_imf_app_name
-      - set_imf_wait_time
 
 # Site URL
 # --------

--- a/imfp/__init__.py
+++ b/imfp/__init__.py
@@ -1,4 +1,16 @@
+"""Python client for the International Monetary Fund's SDMX 3.0 Data API.
+
+The primary interface follows the `econdataverse <https://econdataverse.org/>`_
+conventions: ``imf_get_dataflows`` -> ``imf_get_datastructure`` ->
+``imf_get_codelists`` -> ``imf_get``. See :mod:`imfp.api`.
+
+The older ``imf_databases`` / ``imf_parameters`` / ``imf_parameter_defs`` /
+``imf_dataset`` functions still work but are deprecated, and will be removed in
+imfp 3.0.0.
+"""
+
 from .admin import set_imf_app_name, set_imf_wait_time
+from .api import imf_get, imf_get_codelists, imf_get_dataflows, imf_get_datastructure
 from .data import imf_databases, imf_dataset, imf_parameter_defs, imf_parameters
 from .utils import (
     _download_parse,
@@ -15,7 +27,12 @@ __all__ = [
     "_download_parse",
     "_imf_metadata",
     "_imf_dimensions",
-    "_imf_wait_time",
+    # Econdataverse-style API
+    "imf_get",
+    "imf_get_codelists",
+    "imf_get_dataflows",
+    "imf_get_datastructure",
+    # Deprecated, removal in 3.0.0
     "imf_databases",
     "imf_parameters",
     "imf_parameter_defs",

--- a/imfp/admin.py
+++ b/imfp/admin.py
@@ -1,10 +1,9 @@
 from os import environ
 from warnings import warn
 
-import type_enforced
+from .utils import _require_number, _require_str
 
 
-@type_enforced.Enforcer
 def set_imf_app_name(name: str = "imfp") -> None:
     """
     Set the IMF Application Name.
@@ -20,12 +19,14 @@ def set_imf_app_name(name: str = "imfp") -> None:
         None
 
     Raises:
-        ValueError: If the provided name is not a valid string or contains
-        forbidden characters.
+        TypeError: If the provided name is not a string.
+        ValueError: If the provided name is too long or contains forbidden
+        characters.
 
     Examples:
         imf_app_name("my_custom_app_name")
     """
+    _require_str(name, "name")
 
     if len(name) > 255:
         raise ValueError("Application name must be no longer than 255 characters.")
@@ -51,19 +52,21 @@ def set_imf_app_name(name: str = "imfp") -> None:
     return None
 
 
-@type_enforced.Enforcer
 def set_imf_wait_time(wait_time: int | float = 1.5) -> None:
     """
     Set the IMF wait time as an environment variable.
 
     Args:
-        wait_time (Union[int, float], optional): The wait time in seconds to be set as an environment variable. Defaults to 1.5.
+        wait_time (int or float, optional): The wait time in seconds to be set as
+        an environment variable. Defaults to 1.5.
 
     Raises:
         TypeError: If the provided wait_time is not a numeric value (int or float).
-        ValueError: If the provided wait_time is not greater than 0.
+        ValueError: If the provided wait_time is negative.
     """
-    if wait_time >= 0:
-        environ["IMF_WAIT_TIME"] = str(wait_time)
-    else:
+    _require_number(wait_time, "wait_time")
+
+    if wait_time < 0:
         raise ValueError("Rate limit wait time must be greater than or equal to 0.")
+
+    environ["IMF_WAIT_TIME"] = str(wait_time)

--- a/imfp/api.py
+++ b/imfp/api.py
@@ -16,10 +16,9 @@ one variable per column.
 """
 
 import logging
-from typing import Any
+from typing import Any, Literal, overload
 from warnings import warn
 
-import type_enforced
 from pandas import DataFrame
 
 from .utils import (
@@ -32,19 +31,19 @@ from .utils import (
     _extract_first,
     _get_dataflow_rows,
     _parse_imf_sdmx_json,
+    _require_bool,
+    _require_int,
+    _require_str,
 )
 
 logger = logging.getLogger(__name__)
 
-# Dimension filter kwargs accept one code or a list of codes. They are
-# annotated as Any because type_enforced cannot combine an annotated **kwargs
-# with optional-defaulted parameters; _normalize_dimensions validates them at
-# runtime and reports better errors than the enforcer would.
+# Dimension filter kwargs accept one code or a list of codes.
 DimensionFilter = str | list[str]
 
 
 def _normalize_dimensions(
-    dimensions: dict | None, kwargs: dict[str, Any]
+    dimensions: dict[str, Any] | None, kwargs: dict[str, Any]
 ) -> dict[str, list[str]]:
     """
     (Internal) Merge and normalize dimension filters into ``{DIM: [codes]}``.
@@ -60,9 +59,15 @@ def _normalize_dimensions(
         dict: Upper-cased dimension IDs mapped to lists of string codes.
 
     Raises:
-        ValueError: If the same dimension is supplied twice, or a code is not
-            a string.
+        TypeError: If `dimensions` is not a dict, or a code is not a string.
+        ValueError: If the same dimension is supplied twice.
     """
+    if dimensions is not None and not isinstance(dimensions, dict):
+        raise TypeError(
+            "dimensions must be a dict mapping dimension IDs to codes; "
+            f"got {type(dimensions).__name__} ({dimensions!r})."
+        )
+
     merged: dict[str, list[str]] = {}
 
     for source in (dimensions or {}, kwargs or {}):
@@ -79,7 +84,7 @@ def _normalize_dimensions(
             if isinstance(codes, str):
                 codes = [codes]
             elif isinstance(codes, DataFrame):
-                raise ValueError(
+                raise TypeError(
                     f"Dimension '{key}' was given a DataFrame. The econdataverse "
                     "API takes plain code strings; use "
                     "imf_get_codelists(...)['code'].tolist() to get them."
@@ -92,7 +97,7 @@ def _normalize_dimensions(
 
             bad = [c for c in codes if not isinstance(c, str)]
             if bad:
-                raise ValueError(
+                raise TypeError(
                     f"Dimension '{key}' must be given string code(s); got {bad!r}."
                 )
             normalized: list[str] = [str(code) for code in codes]
@@ -114,14 +119,16 @@ def _normalize_period(period: Any, argument_name: str) -> str | None:
         str: The period as a string, or None.
 
     Raises:
-        ValueError: If the period is not a scalar year or period string.
+        TypeError: If the period is not a scalar year or period string.
+        ValueError: If the period is an empty string.
     """
     if period is None:
         return None
     if isinstance(period, bool) or not isinstance(period, (int, str)):
-        raise ValueError(
+        raise TypeError(
             f"{argument_name} must be a year or period string "
-            f'(e.g. 2015, "2015", "2015-Q1", "2015-01"); got {period!r}.'
+            f'(e.g. 2015, "2015", "2015-Q1", "2015-01"); got '
+            f"{type(period).__name__} ({period!r})."
         )
     period = str(period).strip()
     if not period:
@@ -129,7 +136,6 @@ def _normalize_period(period: Any, argument_name: str) -> str | None:
     return period
 
 
-@type_enforced.Enforcer
 def imf_get_dataflows(max_tries: int = 3) -> DataFrame:
     """
     List every dataset published through the IMF Data API.
@@ -147,13 +153,16 @@ def imf_get_dataflows(max_tries: int = 3) -> DataFrame:
         ``last_updated``.
 
     Raises:
-        ValueError: If the API returns no dataflows.
+        TypeError: If max_tries is not an integer.
+        ValueError: If max_tries is less than 1, or the API returns no dataflows.
 
     Examples:
         # Find the ID of the Primary Commodity Price System dataset
         dataflows = imf_get_dataflows()
         dataflows[dataflows["id"] == "PCPS"]
     """
+    _require_int(max_tries, "max_tries", minimum=1)
+
     rows = []
     for flow in _get_dataflow_rows(times=max_tries):
         flow_id = _extract_first(flow.get("id"))
@@ -185,7 +194,6 @@ def imf_get_dataflows(max_tries: int = 3) -> DataFrame:
     )
 
 
-@type_enforced.Enforcer
 def imf_get_datastructure(
     dataflow_id: str,
     max_tries: int = 3,
@@ -216,12 +224,19 @@ def imf_get_datastructure(
         ``type``, and ``position``.
 
     Raises:
-        ValueError: If the dataflow does not exist or defines no dimensions.
+        TypeError: If an argument has the wrong type.
+        ValueError: If max_tries is less than 1, or the dataflow does not exist
+            or defines no dimensions.
 
     Examples:
         # See what the Primary Commodity Price System can be filtered on
         imf_get_datastructure("PCPS")
     """
+    _require_str(dataflow_id, "dataflow_id")
+    _require_int(max_tries, "max_tries", minimum=1)
+    _require_bool(include_time, "include_time")
+    _require_bool(include_measures, "include_measures")
+
     rows = _dsd_component_rows(
         dataflow_id,
         times=max_tries,
@@ -245,7 +260,6 @@ def imf_get_datastructure(
     return result
 
 
-@type_enforced.Enforcer
 def imf_get_codelists(
     dimension_ids: str | list[str],
     dataflow_id: str,
@@ -271,8 +285,9 @@ def imf_get_codelists(
         enumerated (they accept free-form values) contribute no rows.
 
     Raises:
-        ValueError: If the dataflow does not exist, or if a requested dimension
-            is not part of it.
+        TypeError: If an argument has the wrong type.
+        ValueError: If no dimension is named, if max_tries is less than 1, or if
+            the dataflow does not exist or lacks a requested dimension.
 
     Examples:
         # Find the commodity indicator codes for PCPS
@@ -281,12 +296,25 @@ def imf_get_codelists(
         # Fetch two dimensions at once
         imf_get_codelists(["COMMODITY", "FREQ"], "PCPS")
     """
+    _require_str(dataflow_id, "dataflow_id")
+    _require_int(max_tries, "max_tries", minimum=1)
+
     if isinstance(dimension_ids, str):
         dimension_ids = [dimension_ids]
+    elif not isinstance(dimension_ids, (list, tuple)):
+        raise TypeError(
+            "dimension_ids must be a dimension ID or a list of them; "
+            f"got {type(dimension_ids).__name__} ({dimension_ids!r})."
+        )
+
+    bad = [d for d in dimension_ids if not isinstance(d, str)]
+    if bad:
+        raise TypeError(f"dimension_ids must all be strings; got {bad!r}.")
+
     if not dimension_ids:
         raise ValueError("dimension_ids must name at least one dimension.")
 
-    requested = [str(d).upper() for d in dimension_ids]
+    requested = [d.upper() for d in dimension_ids]
 
     rows = _dsd_component_rows(
         dataflow_id,
@@ -347,17 +375,42 @@ def imf_get_codelists(
     )
 
 
-@type_enforced.Enforcer
+@overload
 def imf_get(
     dataflow_id: str,
-    dimensions: dict | None = None,
+    dimensions: dict[str, Any] | None = None,
+    start_period: int | str | None = None,
+    end_period: int | str | None = None,
+    max_tries: int = 3,
+    print_url: bool = False,
+    return_raw: Literal[False] = False,
+    **kwargs: Any,
+) -> DataFrame: ...
+
+
+@overload
+def imf_get(
+    dataflow_id: str,
+    dimensions: dict[str, Any] | None = None,
+    start_period: int | str | None = None,
+    end_period: int | str | None = None,
+    max_tries: int = 3,
+    print_url: bool = False,
+    return_raw: Literal[True] = True,
+    **kwargs: Any,
+) -> dict[str, Any]: ...
+
+
+def imf_get(
+    dataflow_id: str,
+    dimensions: dict[str, Any] | None = None,
     start_period: int | str | None = None,
     end_period: int | str | None = None,
     max_tries: int = 3,
     print_url: bool = False,
     return_raw: bool = False,
     **kwargs: Any,
-) -> DataFrame | dict:
+) -> DataFrame | dict[str, Any]:
     """
     Fetch observations from an IMF dataset.
 
@@ -393,8 +446,11 @@ def imf_get(
         JSON dict instead.
 
     Raises:
-        ValueError: If the dataflow does not exist, if a named dimension is not
-            part of it, or if the period arguments are malformed.
+        TypeError: If an argument has the wrong type, including a dimension
+            given something other than a code string or list of them.
+        ValueError: If max_tries is less than 1, if the same dimension is
+            supplied twice, or if the dataflow does not exist or lacks a named
+            dimension.
 
     Examples:
         # Annual coal prices, 2000-2015
@@ -408,6 +464,11 @@ def imf_get(
         # The same query using keyword arguments
         imf_get("PCPS", commodity="PCOAL", freq="A", start_period=2000)
     """
+    _require_str(dataflow_id, "dataflow_id")
+    _require_int(max_tries, "max_tries", minimum=1)
+    _require_bool(print_url, "print_url")
+    _require_bool(return_raw, "return_raw")
+
     dimension_filters = _normalize_dimensions(dimensions, kwargs)
     start = _normalize_period(start_period, "start_period")
     end = _normalize_period(end_period, "end_period")

--- a/imfp/api.py
+++ b/imfp/api.py
@@ -1,0 +1,445 @@
+"""Econdataverse-style client for the IMF SDMX 3.0 Data API.
+
+This module follows the conventions shared across the
+`econdataverse <https://econdataverse.org/>`_ family of packages, and mirrors
+the R package `imfapi <https://github.com/Teal-Insights/r-imfapi>`_ so that the
+same workflow reads the same way in either language:
+
+1. :func:`imf_get_dataflows` — discover the available datasets.
+2. :func:`imf_get_datastructure` — see which dimensions a dataset can be
+   filtered on.
+3. :func:`imf_get_codelists` — find the valid codes for those dimensions.
+4. :func:`imf_get` — fetch observations, filtered by the codes you chose.
+
+Every function returns a tidy ``pandas.DataFrame``: one observation per row,
+one variable per column.
+"""
+
+import logging
+from typing import Any
+from warnings import warn
+
+import type_enforced
+from pandas import DataFrame
+
+from .utils import (
+    IMF_API_BASE_URL,
+    _annotation_value,
+    _build_data_request,
+    _component_codelist,
+    _download_parse,
+    _dsd_component_rows,
+    _extract_first,
+    _get_dataflow_rows,
+    _parse_imf_sdmx_json,
+)
+
+logger = logging.getLogger(__name__)
+
+# Dimension filter kwargs accept one code or a list of codes. They are
+# annotated as Any because type_enforced cannot combine an annotated **kwargs
+# with optional-defaulted parameters; _normalize_dimensions validates them at
+# runtime and reports better errors than the enforcer would.
+DimensionFilter = str | list[str]
+
+
+def _normalize_dimensions(
+    dimensions: dict | None, kwargs: dict[str, Any]
+) -> dict[str, list[str]]:
+    """
+    (Internal) Merge and normalize dimension filters into ``{DIM: [codes]}``.
+
+    Dimension IDs are upper-cased so that callers can write them in whatever
+    case is convenient, and scalar codes are wrapped into single-item lists.
+
+    Args:
+        dimensions (dict, optional): Explicit dimension filters.
+        kwargs (dict): Dimension filters passed as keyword arguments.
+
+    Returns:
+        dict: Upper-cased dimension IDs mapped to lists of string codes.
+
+    Raises:
+        ValueError: If the same dimension is supplied twice, or a code is not
+            a string.
+    """
+    merged: dict[str, list[str]] = {}
+
+    for source in (dimensions or {}, kwargs or {}):
+        for name, codes in source.items():
+            key = str(name).upper()
+            if key in merged:
+                raise ValueError(
+                    f"Dimension '{key}' was supplied more than once. Pass each "
+                    "dimension either in `dimensions` or as a keyword argument, "
+                    "not both."
+                )
+            if codes is None:
+                continue
+            if isinstance(codes, str):
+                codes = [codes]
+            elif isinstance(codes, DataFrame):
+                raise ValueError(
+                    f"Dimension '{key}' was given a DataFrame. The econdataverse "
+                    "API takes plain code strings; use "
+                    "imf_get_codelists(...)['code'].tolist() to get them."
+                )
+            else:
+                try:
+                    codes = list(codes)
+                except TypeError:
+                    codes = [codes]
+
+            bad = [c for c in codes if not isinstance(c, str)]
+            if bad:
+                raise ValueError(
+                    f"Dimension '{key}' must be given string code(s); got {bad!r}."
+                )
+            normalized: list[str] = [str(code) for code in codes]
+            if normalized:
+                merged[key] = normalized
+
+    return merged
+
+
+def _normalize_period(period: Any, argument_name: str) -> str | None:
+    """
+    (Internal) Coerce a period argument to a string and reject bad shapes.
+
+    Args:
+        period: A year, or an SDMX-style period. ``None`` passes through.
+        argument_name (str): Name used in the error message.
+
+    Returns:
+        str: The period as a string, or None.
+
+    Raises:
+        ValueError: If the period is not a scalar year or period string.
+    """
+    if period is None:
+        return None
+    if isinstance(period, bool) or not isinstance(period, (int, str)):
+        raise ValueError(
+            f"{argument_name} must be a year or period string "
+            f'(e.g. 2015, "2015", "2015-Q1", "2015-01"); got {period!r}.'
+        )
+    period = str(period).strip()
+    if not period:
+        raise ValueError(f"{argument_name} must not be empty.")
+    return period
+
+
+@type_enforced.Enforcer
+def imf_get_dataflows(max_tries: int = 3) -> DataFrame:
+    """
+    List every dataset published through the IMF Data API.
+
+    This is step 1 of the workflow: use it to find the ``dataflow_id`` of the
+    dataset you want, then pass that ID to the other functions.
+
+    Args:
+        max_tries (int, optional): Maximum number of requests to attempt.
+            Defaults to 3.
+
+    Returns:
+        pandas.DataFrame: One row per dataflow, with columns ``id``, ``name``,
+        ``description``, ``version``, ``agency``, ``structure``, and
+        ``last_updated``.
+
+    Raises:
+        ValueError: If the API returns no dataflows.
+
+    Examples:
+        # Find the ID of the Primary Commodity Price System dataset
+        dataflows = imf_get_dataflows()
+        dataflows[dataflows["id"] == "PCPS"]
+    """
+    rows = []
+    for flow in _get_dataflow_rows(times=max_tries):
+        flow_id = _extract_first(flow.get("id"))
+        if flow_id is None:
+            continue
+        rows.append(
+            {
+                "id": flow_id,
+                "name": _extract_first(flow.get("name")),
+                "description": _extract_first(flow.get("description")),
+                "version": _extract_first(flow.get("version")),
+                "agency": _extract_first(flow.get("agencyID")),
+                "structure": _extract_first(flow.get("structure")),
+                "last_updated": _annotation_value(flow, "lastUpdatedAt"),
+            }
+        )
+
+    return DataFrame(
+        rows,
+        columns=[
+            "id",
+            "name",
+            "description",
+            "version",
+            "agency",
+            "structure",
+            "last_updated",
+        ],
+    )
+
+
+@type_enforced.Enforcer
+def imf_get_datastructure(
+    dataflow_id: str,
+    max_tries: int = 3,
+    include_time: bool = False,
+    include_measures: bool = False,
+) -> DataFrame:
+    """
+    List the dimensions a dataset can be filtered on.
+
+    This is step 2 of the workflow. The returned ``position`` is the dimension's
+    slot in the dataset's series key, which is why the order matters: a request
+    that filters on some dimensions and wildcards others still has to line them
+    up positionally. :func:`imf_get` handles that for you.
+
+    Args:
+        dataflow_id (str): A dataflow ID from imf_get_dataflows().
+        max_tries (int, optional): Maximum number of requests to attempt.
+            Defaults to 3.
+        include_time (bool, optional): Whether to also list the time dimension.
+            Time is filtered through start_period/end_period rather than through
+            the series key, so it is excluded by default.
+        include_measures (bool, optional): Whether to also list measures (the
+            observation values). Measures are outputs, not filters, so they are
+            excluded by default.
+
+    Returns:
+        pandas.DataFrame: One row per component, with columns ``dimension_id``,
+        ``type``, and ``position``.
+
+    Raises:
+        ValueError: If the dataflow does not exist or defines no dimensions.
+
+    Examples:
+        # See what the Primary Commodity Price System can be filtered on
+        imf_get_datastructure("PCPS")
+    """
+    rows = _dsd_component_rows(
+        dataflow_id,
+        times=max_tries,
+        include_time=include_time,
+        include_measures=include_measures,
+    )
+
+    result = DataFrame(
+        [
+            {
+                "dimension_id": row["dimension_id"],
+                "type": row["type"],
+                "position": row["position"],
+            }
+            for row in rows
+        ],
+        columns=["dimension_id", "type", "position"],
+    )
+    # Nullable integer: measures have no position in the series key.
+    result["position"] = result["position"].astype("Int64")
+    return result
+
+
+@type_enforced.Enforcer
+def imf_get_codelists(
+    dimension_ids: str | list[str],
+    dataflow_id: str,
+    max_tries: int = 3,
+) -> DataFrame:
+    """
+    Look up the valid codes for one or more of a dataset's dimensions.
+
+    This is step 3 of the workflow: the ``code`` column holds the values to pass
+    to :func:`imf_get`.
+
+    Args:
+        dimension_ids (str or list): One or more dimension IDs from
+            imf_get_datastructure(). Matching is case-insensitive.
+        dataflow_id (str): A dataflow ID from imf_get_dataflows().
+        max_tries (int, optional): Maximum number of requests to attempt.
+            Defaults to 3.
+
+    Returns:
+        pandas.DataFrame: One row per code, with columns ``dimension_id``,
+        ``code``, ``name``, ``description``, ``codelist_id``,
+        ``codelist_agency``, and ``codelist_version``. Dimensions that are not
+        enumerated (they accept free-form values) contribute no rows.
+
+    Raises:
+        ValueError: If the dataflow does not exist, or if a requested dimension
+            is not part of it.
+
+    Examples:
+        # Find the commodity indicator codes for PCPS
+        imf_get_codelists("COMMODITY", "PCPS")
+
+        # Fetch two dimensions at once
+        imf_get_codelists(["COMMODITY", "FREQ"], "PCPS")
+    """
+    if isinstance(dimension_ids, str):
+        dimension_ids = [dimension_ids]
+    if not dimension_ids:
+        raise ValueError("dimension_ids must name at least one dimension.")
+
+    requested = [str(d).upper() for d in dimension_ids]
+
+    rows = _dsd_component_rows(
+        dataflow_id,
+        times=max_tries,
+        include_time=True,
+        include_measures=True,
+    )
+    by_id = {row["dimension_id"].upper(): row for row in rows}
+
+    unknown = [d for d in requested if d not in by_id]
+    if unknown:
+        raise ValueError(
+            f"Unknown dimension(s) for {dataflow_id}: {', '.join(unknown)}. "
+            f"Available: {', '.join(sorted(by_id))}. "
+            f"Use imf_get_datastructure('{dataflow_id}') to list them."
+        )
+
+    memo: dict[str, Any] = {}
+    records = []
+    for dimension_id in requested:
+        row = by_id[dimension_id]
+        ref, codes = _component_codelist(row["component"], times=max_tries, memo=memo)
+        if not codes:
+            logger.debug(
+                "Dimension %s of %s is not enumerated; no codes to list.",
+                dimension_id,
+                dataflow_id,
+            )
+            continue
+
+        for code in codes:
+            code_id = _extract_first(code.get("id"))
+            if not code_id:
+                continue
+            records.append(
+                {
+                    "dimension_id": row["dimension_id"],
+                    "code": code_id,
+                    "name": _extract_first(code.get("name")),
+                    "description": _extract_first(code.get("description")),
+                    "codelist_id": ref["id"],
+                    "codelist_agency": ref["agency"],
+                    "codelist_version": ref["version"],
+                }
+            )
+
+    return DataFrame(
+        records,
+        columns=[
+            "dimension_id",
+            "code",
+            "name",
+            "description",
+            "codelist_id",
+            "codelist_agency",
+            "codelist_version",
+        ],
+    )
+
+
+@type_enforced.Enforcer
+def imf_get(
+    dataflow_id: str,
+    dimensions: dict | None = None,
+    start_period: int | str | None = None,
+    end_period: int | str | None = None,
+    max_tries: int = 3,
+    print_url: bool = False,
+    return_raw: bool = False,
+    **kwargs: Any,
+) -> DataFrame | dict:
+    """
+    Fetch observations from an IMF dataset.
+
+    This is step 4 of the workflow. Dimensions you do not filter on are
+    wildcarded, so omitting ``dimensions`` entirely requests the whole dataset —
+    which for most datasets is slow and very large.
+
+    Codes are not validated before the request is sent; the API is the authority
+    on what is valid. Use :func:`imf_get_codelists` to find valid codes.
+
+    Args:
+        dataflow_id (str): A dataflow ID from imf_get_dataflows().
+        dimensions (dict, optional): Maps dimension IDs to the code or list of
+            codes to include. Dimension IDs are matched case-insensitively.
+        start_period (int or str, optional): Earliest period to return, as a
+            year ("2015"), quarter ("2015-Q1"), or month ("2015-01").
+        end_period (int or str, optional): Latest period to return, in the same
+            formats as start_period.
+        max_tries (int, optional): Maximum number of requests to attempt.
+            Defaults to 3.
+        print_url (bool, optional): Whether to print the request URL, which is
+            useful when reporting a problem with a specific query.
+        return_raw (bool, optional): Whether to return the parsed JSON response
+            as a dict instead of a DataFrame.
+        **kwargs: Dimension filters given as keyword arguments, e.g.
+            ``freq="A"``. Equivalent to passing them in ``dimensions``.
+
+    Returns:
+        pandas.DataFrame: One row per observation, with a column per series
+        dimension (named as in the datastructure), plus ``TIME_PERIOD`` and
+        ``OBS_VALUE``. Returns an empty DataFrame, and warns, when the query
+        matches no observations. If return_raw is True, returns the raw parsed
+        JSON dict instead.
+
+    Raises:
+        ValueError: If the dataflow does not exist, if a named dimension is not
+            part of it, or if the period arguments are malformed.
+
+    Examples:
+        # Annual coal prices, 2000-2015
+        imf_get(
+            "PCPS",
+            dimensions={"COMMODITY": "PCOAL", "FREQ": "A"},
+            start_period=2000,
+            end_period=2015,
+        )
+
+        # The same query using keyword arguments
+        imf_get("PCPS", commodity="PCOAL", freq="A", start_period=2000)
+    """
+    dimension_filters = _normalize_dimensions(dimensions, kwargs)
+    start = _normalize_period(start_period, "start_period")
+    end = _normalize_period(end_period, "end_period")
+
+    if not dimension_filters:
+        logger.info("No dimension filters supplied; requesting all of %s.", dataflow_id)
+
+    data_path, query_params = _build_data_request(
+        dataflow_id,
+        dimension_filters,
+        start_period=start,
+        end_period=end,
+        times=max_tries,
+    )
+
+    if print_url:
+        from urllib.parse import urlencode
+
+        print(f"{IMF_API_BASE_URL.rstrip('/')}/{data_path}?{urlencode(query_params)}")
+
+    message = _download_parse(data_path, times=max_tries, query_params=query_params)
+
+    if return_raw:
+        return message
+
+    result = _parse_imf_sdmx_json(message)
+
+    if result.empty:
+        warn(
+            f"No observations matched that query against {dataflow_id}. "
+            "Try relaxing the dimension filters or the time window.",
+            UserWarning,
+        )
+
+    return result

--- a/imfp/data.py
+++ b/imfp/data.py
@@ -14,7 +14,6 @@ from typing import Any, Literal, TypeVar, overload
 from urllib.parse import urlencode
 from warnings import warn
 
-import type_enforced
 from pandas import DataFrame
 
 from .api import imf_get_dataflows
@@ -27,6 +26,9 @@ from .utils import (
     _extract_first,
     _find_dataflow,
     _imf_dimensions,
+    _require_bool,
+    _require_int,
+    _require_str,
 )
 
 # _parse_imf_sdmx_json and _transform_period_for_frequency moved to utils so the
@@ -213,7 +215,6 @@ def _normalized_dimension_filters(
     return norm_dims
 
 
-@type_enforced.Enforcer
 def imf_databases(times: int = 3) -> DataFrame:
     """
     List IMF database IDs and descriptions
@@ -240,6 +241,8 @@ def imf_databases(times: int = 3) -> DataFrame:
     # Return first 6 IMF database IDs and descriptions
     databases = imf_databases()
     """
+    _require_int(times, "times", minimum=1)
+
     _warn_deprecated("imf_databases")
 
     dataflows = imf_get_dataflows(max_tries=times)
@@ -256,7 +259,6 @@ def imf_databases(times: int = 3) -> DataFrame:
     ).reset_index(drop=True)
 
 
-@type_enforced.Enforcer
 def imf_parameters(database_id: str, times: int = 2) -> dict[str, DataFrame]:
     """
     List input parameters and available parameter values for use in
@@ -291,6 +293,9 @@ def imf_parameters(database_id: str, times: int = 2) -> dict[str, DataFrame]:
     # Commodity Price System database
     params = imf_parameters(database_id='PCPS')
     """
+    _require_str(database_id, "database_id")
+    _require_int(times, "times", minimum=1)
+
     _warn_deprecated("imf_parameters")
 
     try:
@@ -332,7 +337,6 @@ def imf_parameters(database_id: str, times: int = 2) -> dict[str, DataFrame]:
     return parameter_list
 
 
-@type_enforced.Enforcer
 def imf_parameter_defs(
     database_id: str, times: int = 3, inputs_only: bool = True
 ) -> DataFrame:
@@ -369,6 +373,10 @@ def imf_parameter_defs(
     # the Primary Commodity Price System database
     param_defs = imf_parameter_defs(database_id='PCPS')
     """
+    _require_str(database_id, "database_id")
+    _require_int(times, "times", minimum=1)
+    _require_bool(inputs_only, "inputs_only")
+
     _warn_deprecated("imf_parameter_defs")
 
     try:
@@ -494,6 +502,17 @@ def imf_dataset(
         database header, and whose second item is the pandas DataFrame. If
         return_raw == True, returns the raw JSON fetched from the API endpoint.
     """
+    _require_str(database_id, "database_id")
+    _require_int(times, "times", minimum=1)
+    _require_bool(return_raw, "return_raw")
+    _require_bool(print_url, "print_url")
+    _require_bool(include_metadata, "include_metadata")
+    if parameters is not None and not isinstance(parameters, dict):
+        raise TypeError(
+            "parameters must be a dict of DataFrames from imf_parameters(); "
+            f"got {type(parameters).__name__}."
+        )
+
     _warn_deprecated("imf_dataset")
 
     start_period = _normalize_year_arg(start_year, "start_year")

--- a/imfp/data.py
+++ b/imfp/data.py
@@ -1,5 +1,15 @@
+"""Legacy ``imf_*`` interface, retained for backward compatibility.
+
+Every function in this module is deprecated in favor of the econdataverse-style
+API in :mod:`imfp.api`. See ``_DEPRECATION_MAP`` for the replacement of each.
+
+The request-building and response-parsing mechanics these functions rely on
+live in :mod:`imfp.utils`, shared with the new API so both paths return
+identical data. ``_parse_imf_sdmx_json`` and ``_transform_period_for_frequency``
+are re-exported here because they were previously defined in this module.
+"""
+
 import logging
-import re
 from typing import Any, Literal, TypeVar, overload
 from urllib.parse import urlencode
 from warnings import warn
@@ -7,152 +17,52 @@ from warnings import warn
 import type_enforced
 from pandas import DataFrame
 
+from .api import imf_get_dataflows
 from .utils import (
     IMF_API_BASE_URL,
+    _build_data_request,
+    _component_codelist,
     _download_parse,
+    _dsd_component_rows,
     _extract_first,
     _find_dataflow,
-    _get_datastructure_components,
     _imf_dimensions,
 )
+
+# _parse_imf_sdmx_json and _transform_period_for_frequency moved to utils so the
+# new API can share them. They are re-exported here, in the explicit
+# "import X as X" form, because they used to be defined in this module and the
+# pre-2.0 tests still import them from it.
+from .utils import _parse_imf_sdmx_json as _parse_imf_sdmx_json
+from .utils import _transform_period_for_frequency as _transform_period_for_frequency
 
 logger = logging.getLogger(__name__)
 
 _FREQ_ALIASES = ("freq", "frequency")
 _REF_AREA_ALIASES = ("ref_area", "refarea", "ref-area", "country", "geo")
-_PERIOD_FREQ_SUFFIX = re.compile(r"^\d{4}-(M|Q|A|W)\d+$")
-_PERIOD_MONTH = re.compile(r"^\d{4}-\d{2}$")
-_PERIOD_YEAR = re.compile(r"^\d{4}$")
 
 # Dimension filter kwargs accept one code or a list of codes.
 DimensionFilter = str | list[str]
 _T = TypeVar("_T")
 
+# Legacy function -> the econdataverse-style function that replaces it.
+_DEPRECATION_MAP = {
+    "imf_databases": "imf_get_dataflows",
+    "imf_parameters": "imf_get_codelists",
+    "imf_parameter_defs": "imf_get_datastructure",
+    "imf_dataset": "imf_get",
+}
 
-def _parse_imf_sdmx_json(message: dict[str, Any]) -> DataFrame:
-    """
-    Parse SDMX JSON message from new API into a DataFrame.
 
-    Matches the R implementation's parse_imf_sdmx_json function.
-
-    Args:
-        message: The JSON response from the API
-
-    Returns:
-        DataFrame with one row per observation
-    """
-    # Defensive checks
-    if not message or not message.get("data"):
-        return DataFrame()
-
-    data_sets = message.get("data", {}).get("dataSets")
-    structures = message.get("data", {}).get("structures")
-
-    if not data_sets or len(data_sets) < 1 or not structures or len(structures) < 1:
-        return DataFrame()
-
-    ds = data_sets[0]
-    st = structures[0]
-
-    # Dimensions metadata
-    series_dims = st.get("dimensions", {}).get("series", [])
-    obs_dims = st.get("dimensions", {}).get("observation", [])
-    obs_dim = obs_dims[0] if obs_dims and len(obs_dims) >= 1 else None
-
-    # Helper to map index -> code/id
-    def index_to_code(dim_def: dict[str, Any] | None, idx: Any) -> Any:
-        if not dim_def or not dim_def.get("values") or len(dim_def["values"]) < 1:
-            return None
-        try:
-            i = int(idx)
-            i = i + 1  # Convert from 0-based to 1-based
-            if i < 1 or i > len(dim_def["values"]):
-                return None
-            v = dim_def["values"][i - 1]  # Python is 0-based
-            return v.get("id") or v.get("value")
-        except (ValueError, IndexError, TypeError):
-            return None
-
-    def obs_index_to_period(idx: Any) -> Any:
-        if not obs_dim or not obs_dim.get("values") or len(obs_dim["values"]) < 1:
-            return None
-        try:
-            i = int(idx)
-            i = i + 1  # Convert from 0-based to 1-based
-            if i < 1 or i > len(obs_dim["values"]):
-                return None
-            v = obs_dim["values"][i - 1]  # Python is 0-based
-            return v.get("value") or v.get("id")
-        except (ValueError, IndexError, TypeError):
-            return None
-
-    # No series present -> empty DataFrame
-    if not ds.get("series") or len(ds["series"]) == 0:
-        return DataFrame()
-
-    # Prepare column names for series dimensions
-    series_dim_ids = []
-    if series_dims and len(series_dims) > 0:
-        series_dim_ids = [_extract_first(dim.get("id")) for dim in series_dims]
-
-    # Build rows
-    rows = []
-    series_keys = list(ds["series"].keys())
-
-    for sk in series_keys:
-        s_entry = ds["series"][sk]
-        # Decode series key indices to codes
-        sk_parts = sk.split(":")
-        # Ensure length matches; pad if necessary
-        if len(sk_parts) < len(series_dim_ids):
-            sk_parts.extend([None] * (len(series_dim_ids) - len(sk_parts)))
-
-        series_codes = []
-        if len(series_dim_ids) > 0:
-            for dim_def, idx in zip(series_dims, sk_parts):
-                code = index_to_code(dim_def, idx) if idx is not None else None
-                series_codes.append(code)
-
-        # Process observations
-        obs_keys = list(s_entry.get("observations", {}).keys())
-        if len(obs_keys) == 0:
-            continue
-
-        for ok in obs_keys:
-            obs = s_entry["observations"][ok]
-            # Observation value is the first element; handle None gracefully
-            obs_val_raw = obs[0] if len(obs) >= 1 else None
-            obs_val_num = None
-
-            if obs_val_raw is not None:
-                try:
-                    obs_val_num = float(obs_val_raw)
-                except (ValueError, TypeError):
-                    # Map common non-numeric flags to None
-                    if isinstance(obs_val_raw, str) and obs_val_raw.upper() in (
-                        "NA",
-                        "NP",
-                        "ND",
-                        "N/A",
-                    ):
-                        obs_val_num = None
-
-            time_period = obs_index_to_period(ok)
-
-            # Build row
-            row = {}
-            for dim_id, code in zip(series_dim_ids, series_codes):
-                row[dim_id] = code
-            row["TIME_PERIOD"] = time_period
-            row["OBS_VALUE"] = obs_val_num
-            rows.append(row)
-
-    if len(rows) == 0:
-        return DataFrame()
-
-    # Convert to DataFrame
-    df = DataFrame(rows)
-    return df
+def _warn_deprecated(name: str) -> None:
+    """Emit the standard deprecation notice for a legacy ``imf_*`` function."""
+    warn(
+        f"imfp.{name}() is deprecated and will be removed in imfp 3.0.0. "
+        f"Use imfp.{_DEPRECATION_MAP[name]}() instead. See "
+        "https://promptlytechnologies.com/imfp/ for the migration guide.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
 
 
 def _normalize_year_arg(value: Any, arg_name: str) -> str | None:
@@ -303,116 +213,14 @@ def _normalized_dimension_filters(
     return norm_dims
 
 
-def _series_key_rows(components: dict[str, Any]) -> list[dict[str, Any]]:
-    """Return non-time dimensions sorted by position for series-key construction."""
-    dims = components.get("dimensionList", {}).get("dimensions", [])
-    time_dims = components.get("dimensionList", {}).get("timeDimensions", [])
-    all_dim_rows: list[dict[str, Any]] = []
-    for dim in list(dims) + list(time_dims or []):
-        if not dim:
-            continue
-        dim_id = _extract_first(dim.get("id"))
-        position = dim.get("position")
-        dim_type = _extract_first(dim.get("type"))
-        if dim_id and position is not None:
-            all_dim_rows.append(
-                {
-                    "id": dim_id.upper(),
-                    "position": int(position),
-                    "type": dim_type,
-                }
-            )
-    key_rows = [row for row in all_dim_rows if row["type"] != "TimeDimension"]
-    key_rows.sort(key=lambda x: x["position"])
-    return key_rows
-
-
-def _build_series_key(
-    key_rows: list[dict[str, Any]], norm_dims: dict[str, list[str]]
-) -> str:
-    available_dims = {row["id"] for row in key_rows}
-    unknown = set(norm_dims) - available_dims
-    if unknown:
-        raise ValueError(
-            f"Unknown dimension(s): {', '.join(sorted(unknown))}. "
-            f"Available dimensions: {', '.join(sorted(available_dims))}"
-        )
-    segments = []
-    for row in key_rows:
-        vals = norm_dims.get(row["id"], [])
-        # Omitted dimensions (including omitted frequency) become '*' wildcards.
-        segments.append("*" if not vals else "+".join(vals))
-    return ".".join(segments)
-
-
-def _transform_period_for_frequency(
-    period: str | None,
-    frequency: list[str] | None,
-    bound: Literal["start", "end"] = "start",
-) -> str | None:
-    """Transform a user time period into the SDMX filter form for a frequency.
-
-    When ``frequency`` is a single code, year bounds use that frequency's first
-    (start) or last (end) period of the year. When frequency is omitted or
-    multi-valued, start uses the earliest cross-frequency suffix (``-A1``) and
-    end uses a high sentinel (``-W99``) so quarterly/monthly periods in the
-    requested year are not excluded by lexicographic comparison.
-    """
-    if not period:
-        return period
-    if _PERIOD_FREQ_SUFFIX.match(period):
-        return period
-    if _PERIOD_MONTH.match(period):
-        year, month = period.split("-")
-        return f"{year}-M{month}"
-    if _PERIOD_YEAR.match(period):
-        start_suffixes = {"A": "-A1", "Q": "-Q1", "M": "-M01", "W": "-W01"}
-        end_suffixes = {"A": "-A1", "Q": "-Q4", "M": "-M12", "W": "-W53"}
-        if frequency and len(frequency) == 1:
-            freq = frequency[0].upper()
-            suffix_map = end_suffixes if bound == "end" else start_suffixes
-            suffix = suffix_map.get(freq, "-A1" if bound == "start" else "-W99")
-        else:
-            suffix = "-A1" if bound == "start" else "-W99"
-        return f"{period}{suffix}"
-    return period
-
-
-def _build_time_query_params(
-    start_period: str | None,
-    end_period: str | None,
-    user_frequency: list[str] | None,
-    provider_agency: str,
-) -> dict[str, str]:
-    query_params = {
-        "dimensionAtObservation": "TIME_PERIOD",
-        "attributes": "dsd",
-        "measures": "all",
-    }
-    time_filters = []
-    if start_period:
-        time_filters.append(
-            f"ge:{_transform_period_for_frequency(start_period, user_frequency, bound='start')}"
-        )
-    if end_period:
-        time_filters.append(
-            f"le:{_transform_period_for_frequency(end_period, user_frequency, bound='end')}"
-        )
-    if time_filters:
-        if provider_agency == "IMF.STA":
-            query_params["c[TIME_PERIOD]"] = "+".join(time_filters)
-        else:
-            warn(
-                f"Agency {provider_agency} does not support time filters; "
-                "time window will be ignored."
-            )
-    return query_params
-
-
 @type_enforced.Enforcer
 def imf_databases(times: int = 3) -> DataFrame:
     """
     List IMF database IDs and descriptions
+
+    .. deprecated:: 2.0.0
+       Use :func:`imfp.imf_get_dataflows` instead. This function will be
+       removed in imfp 3.0.0.
 
     Returns a DataFrame with database_id and text description for each
     database available through the IMF API endpoint.
@@ -432,48 +240,32 @@ def imf_databases(times: int = 3) -> DataFrame:
     # Return first 6 IMF database IDs and descriptions
     databases = imf_databases()
     """
-    # Use new API endpoint: structure/dataflow/all/*/+ where '+' means latest stable version
-    raw_dl = _download_parse("structure/dataflow/all/*/+", times=times)
+    _warn_deprecated("imf_databases")
 
-    # New API structure: body["data"]["dataflows"] is a list of dataflow objects
-    raw_dataflows = raw_dl.get("data", {}).get("dataflows")
-    if raw_dataflows is None:
-        raise ValueError("No dataflows found in API response.")
+    dataflows = imf_get_dataflows(max_tries=times)
 
-    # Extract database_id and description from each dataflow
-    # The new API structure has: id, name, description, version, agencyID, structure, annotations
-    # In the R implementation, these are lists and we take the first element [[1]]
-    database_id = []
-    description = []
+    # The legacy contract calls the dataflow's name its "description", and
+    # promises no missing values, so fall back through name -> description -> "".
+    description = dataflows["name"].fillna(dataflows["description"]).fillna("")
 
-    for dataflow in raw_dataflows:
-        # Extract id (database_id)
-        dataflow_id = _extract_first(dataflow.get("id"))
-        if dataflow_id is None:
-            continue  # Skip if no ID
-
-        # Extract name (used as description for backward compatibility)
-        # The old API used Name["#text"] which was the name, not description
-        name = _extract_first(dataflow.get("name"))
-        if name is None:
-            # Fallback to description if name is not available
-            name = _extract_first(dataflow.get("description"))
-            if name is None:
-                name = ""  # Empty string if neither name nor description available
-
-        database_id.append(dataflow_id)
-        description.append(name)
-
-    database_list = DataFrame({"database_id": database_id, "description": description})
-    return database_list
+    return DataFrame(
+        {
+            "database_id": dataflows["id"],
+            "description": description,
+        }
+    ).reset_index(drop=True)
 
 
 @type_enforced.Enforcer
 def imf_parameters(database_id: str, times: int = 2) -> dict[str, DataFrame]:
     """
     List input parameters and available parameter values for use in
-
     making API requests from a given IMF database.
+
+    .. deprecated:: 2.0.0
+       Use :func:`imfp.imf_get_codelists` instead, which returns a single tidy
+       DataFrame rather than a dict of DataFrames. This function will be
+       removed in imfp 3.0.0.
 
     Parameters
     ----------
@@ -499,74 +291,43 @@ def imf_parameters(database_id: str, times: int = 2) -> dict[str, DataFrame]:
     # Commodity Price System database
     params = imf_parameters(database_id='PCPS')
     """
+    _warn_deprecated("imf_parameters")
+
     try:
-        codelist = _imf_dimensions(database_id, times)
+        rows = _dsd_component_rows(database_id, times=times)
     except ValueError as e:
-        if "There is an issue" in str(e) or "not found" in str(e).lower():
-            raise ValueError(
-                f"{e}\n\nDid you supply a valid database_id? Use imf_databases to find."
-            )
-        else:
-            raise ValueError(e)
-
-    def fetch_parameter_data(k: int, times: int) -> DataFrame:
-        codelist_id = str(codelist.loc[k, "code"])
-        agency_raw = codelist.loc[k, "agency"]
-        codelist_agency = None if agency_raw is None else str(agency_raw)
-
-        # Fetch codelist using new API
-        # Try agency-specific path first to get the correct version,
-        # then fallback to 'all' if the agency path fails
-        cl_paths = []
-        if codelist_agency:
-            cl_paths.append(f"structure/codelist/{codelist_agency}/{codelist_id}/+")
-        cl_paths.append(f"structure/codelist/all/{codelist_id}/+")
-
-        cl_body = None
-        for cl_path in cl_paths:
-            try:
-                cl_body = _download_parse(cl_path, times=times)
-                break
-            except ValueError:
-                continue
-
-        if cl_body is None:
-            raise ValueError(f"Codelist {codelist_id} not found.")
-
-        clists = cl_body.get("data", {}).get("codelists", [])
-        if not clists or len(clists) < 1:
-            raise ValueError(f"Empty codelists payload for {codelist_id}.")
-
-        codes_list = clists[0].get("codes", [])
-        if not codes_list:
-            raise ValueError(f"No codes found in codelist {codelist_id}.")
-
-        # Extract codes and descriptions
-        input_codes = []
-        code_descriptions = []
-
-        for code_obj in codes_list:
-            code_id = _extract_first(code_obj.get("id"))
-            code_name = _extract_first(code_obj.get("name"))
-            code_desc = _extract_first(code_obj.get("description"))
-
-            if code_id:
-                input_codes.append(code_id)
-                # Use name if available, otherwise description, otherwise code_id
-                desc = code_name if code_name else (code_desc if code_desc else code_id)
-                code_descriptions.append(desc)
-
-        return DataFrame(
-            {
-                "input_code": input_codes,
-                "description": code_descriptions,
-            }
+        raise ValueError(
+            f"{e}\n\nDid you supply a valid database_id? Use imf_databases to find."
         )
 
-    parameter_list: dict[str, DataFrame] = {
-        str(codelist.loc[k, "parameter"]): fetch_parameter_data(k, times)
-        for k in range(codelist.shape[0])
-    }
+    memo: dict[str, Any] = {}
+    parameter_list = {}
+    for row in rows:
+        ref, codes = _component_codelist(row["component"], times=times, memo=memo)
+        # inputs_only semantics: unenumerated dimensions are not filterable.
+        if not codes:
+            continue
+
+        input_codes = []
+        descriptions = []
+        for code in codes:
+            code_id = _extract_first(code.get("id"))
+            if not code_id:
+                continue
+            name = _extract_first(code.get("name"))
+            description = _extract_first(code.get("description"))
+            input_codes.append(code_id)
+            descriptions.append(name or description or code_id)
+
+        parameter_list[row["dimension_id"].lower()] = DataFrame(
+            {"input_code": input_codes, "description": descriptions}
+        )
+
+    if not parameter_list:
+        raise ValueError(
+            f"No filterable parameters found for {database_id}. "
+            "Did you supply a valid database_id? Use imf_databases to find."
+        )
 
     return parameter_list
 
@@ -578,6 +339,10 @@ def imf_parameter_defs(
     """
     Get text descriptions of input parameters used in making API
     requests from a given IMF database
+
+    .. deprecated:: 2.0.0
+       Use :func:`imfp.imf_get_datastructure` instead. This function will be
+       removed in imfp 3.0.0.
 
     Parameters
     ----------
@@ -604,6 +369,8 @@ def imf_parameter_defs(
     # the Primary Commodity Price System database
     param_defs = imf_parameter_defs(database_id='PCPS')
     """
+    _warn_deprecated("imf_parameter_defs")
+
     try:
         parameterlist = _imf_dimensions(database_id, times, inputs_only)[
             ["parameter", "description"]
@@ -689,6 +456,10 @@ def imf_dataset(
     """
     Download a data series from the IMF.
 
+    .. deprecated:: 2.0.0
+       Use :func:`imfp.imf_get` instead. This function will be removed in
+       imfp 3.0.0.
+
     Args:
         database_id (str): Database ID for the database from which you would
                            like to request data. Can be found using
@@ -723,6 +494,8 @@ def imf_dataset(
         database header, and whose second item is the pandas DataFrame. If
         return_raw == True, returns the raw JSON fetched from the API endpoint.
     """
+    _warn_deprecated("imf_dataset")
+
     start_period = _normalize_year_arg(start_year, "start_year")
     end_period = _normalize_year_arg(end_year, "end_year")
     dimension_filters = _validate_dimension_filters(kwargs)
@@ -763,21 +536,15 @@ def imf_dataset(
 
     # One dataflow lookup serves both DSD resolution and provider agency.
     flow_row = _find_dataflow(database_id, times=times)
-    components = _get_datastructure_components(
-        database_id, times=times, flow_row=flow_row
-    )
-    key_rows = _series_key_rows(components)
-    key = _build_series_key(key_rows, norm_dims)
-
-    available_dims = {row["id"] for row in key_rows}
-    freq_dim_id = next((d for d in ("FREQUENCY", "FREQ") if d in available_dims), None)
-    user_frequency = norm_dims.get(freq_dim_id) if freq_dim_id else None
-    provider_agency = _extract_first(flow_row.get("agencyID")) or "all"
-    query_params = _build_time_query_params(
-        start_period, end_period, user_frequency, provider_agency
+    data_path, query_params = _build_data_request(
+        database_id,
+        norm_dims,
+        start_period=start_period,
+        end_period=end_period,
+        times=times,
+        flow_row=flow_row,
     )
 
-    data_path = f"data/dataflow/{provider_agency}/{database_id}/+/{key}"
     if print_url:
         full_url = f"{IMF_API_BASE_URL.rstrip('/')}/{data_path}"
         if query_params:

--- a/imfp/utils.py
+++ b/imfp/utils.py
@@ -5,8 +5,9 @@ from collections.abc import Callable
 from json import JSONDecodeError, dump, load, loads
 from os import environ, path
 from time import perf_counter, sleep
-from typing import Any, ParamSpec, TypeVar
+from typing import Any, Literal, ParamSpec, TypeVar
 from urllib.parse import urljoin, urlparse
+from warnings import warn
 
 from pandas import DataFrame
 from requests import Response, get
@@ -413,6 +414,27 @@ def _parse_codelist_urn(urn: str) -> dict[str, str | None]:
     }
 
 
+def _get_dataflow_rows(times: int = 3) -> list[dict[str, Any]]:
+    """
+    (Internal) Fetch the raw list of dataflow objects from the IMF catalog.
+
+    Args:
+        times (int, optional): The number of times to retry the request.
+            Defaults to 3.
+
+    Returns:
+        list: Raw dataflow dictionaries as returned by the API.
+
+    Raises:
+        ValueError: If the response contains no dataflows.
+    """
+    raw_dl = _download_parse("structure/dataflow/all/*/+", times=times)
+    raw_dataflows = raw_dl.get("data", {}).get("dataflows")
+    if raw_dataflows is None:
+        raise ValueError("No dataflows found in API response.")
+    return raw_dataflows
+
+
 def _find_dataflow(dataflow_id: str, times: int = 3) -> dict[str, Any]:
     """
     (Internal) Look up a dataflow object by ID from the IMF dataflow catalog.
@@ -425,16 +447,19 @@ def _find_dataflow(dataflow_id: str, times: int = 3) -> dict[str, Any]:
     Returns:
         dict: The matching dataflow object from the API response.
     """
-    raw_dl = _download_parse("structure/dataflow/all/*/+", times=times)
-    raw_dataflows = raw_dl.get("data", {}).get("dataflows")
-    if raw_dataflows is None:
-        raise ValueError("No dataflows found in API response.")
-
-    for flow in raw_dataflows:
+    for flow in _get_dataflow_rows(times=times):
         if _extract_first(flow.get("id")) == dataflow_id:
             return flow
 
     raise ValueError(f"Dataflow not found or not unique: {dataflow_id}.")
+
+
+def _annotation_value(obj: dict[str, Any], annotation_id: str) -> str | None:
+    """Return the value of a named annotation on an SDMX artefact, if present."""
+    for annotation in obj.get("annotations", []) or []:
+        if annotation.get("id") == annotation_id:
+            return annotation.get("value")
+    return None
 
 
 def _get_datastructure_components(
@@ -492,6 +517,201 @@ def _get_datastructure_components(
     return components
 
 
+def _component_codelist(
+    component: dict[str, Any],
+    times: int = 3,
+    memo: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """
+    (Internal) Resolve the codelist that enumerates a datastructure component.
+
+    A component's codelist is normally declared indirectly, via the concept it
+    points at through ``conceptIdentity``; some components instead declare it
+    inline through ``localRepresentation``. This resolves either form and
+    fetches the codelist.
+
+    Args:
+        component (dict): A raw dimension, time dimension, or measure object
+            from a datastructure definition.
+        times (int, optional): The number of times to retry each request.
+            Defaults to 3.
+        memo (dict, optional): Mutable cache, keyed by URN, shared across calls
+            so that dimensions sharing a codelist only trigger one request.
+
+    Returns:
+        tuple: ``(ref, codes)``, where ``ref`` is a dict with ``id``, ``agency``,
+        ``version``, and ``name`` keys (values are None when unresolved) and
+        ``codes`` is the list of raw code objects (empty when unenumerated).
+    """
+    if memo is None:
+        memo = {}
+
+    empty_ref: dict[str, Any] = {
+        "id": None,
+        "agency": None,
+        "version": None,
+        "name": None,
+    }
+
+    concept_identity = _extract_first(component.get("conceptIdentity"))
+
+    local_enum = None
+    local_rep = component.get("localRepresentation") or {}
+    if local_rep:
+        local_enum = _extract_first(local_rep.get("enumeration"))
+
+    if not concept_identity:
+        # Without a concept identity there is nothing to resolve beyond the
+        # component's own inline representation.
+        enum_urn = local_enum
+    else:
+        cref = _parse_concept_urn(concept_identity)
+        enum_urn = local_enum
+        if cref.get("agency") and cref.get("scheme") and cref.get("concept"):
+            cs_key = f"conceptscheme:{cref['agency']}:{cref['scheme']}"
+            if cs_key in memo:
+                cs_body = memo[cs_key]
+            else:
+                cs_body = None
+                for cs_path in (
+                    f"structure/conceptscheme/{cref['agency']}/{cref['scheme']}/+",
+                    f"structure/conceptscheme/all/{cref['scheme']}/+",
+                ):
+                    try:
+                        cs_body = _download_parse(cs_path, times=times)
+                        break
+                    except ValueError:
+                        continue
+                memo[cs_key] = cs_body
+
+            if cs_body is not None:
+                concept = None
+                for cs in cs_body.get("data", {}).get("conceptSchemes", []):
+                    for cn in cs.get("concepts", []) or []:
+                        if _extract_first(cn.get("id")) == cref["concept"]:
+                            concept = cn
+                            break
+                    if concept:
+                        break
+
+                enum_from_concept = None
+                if concept:
+                    core_rep = concept.get("coreRepresentation") or {}
+                    if core_rep:
+                        enum_from_concept = _extract_first(core_rep.get("enumeration"))
+
+                enum_urn = enum_from_concept if enum_from_concept else local_enum
+
+    if not enum_urn:
+        return empty_ref, []
+
+    cl = _parse_codelist_urn(enum_urn)
+    if not cl.get("agency") or not cl.get("id"):
+        return empty_ref, []
+
+    cl_key = f"codelist:{cl['agency']}:{cl['id']}"
+    if cl_key in memo:
+        cl_body = memo[cl_key]
+    else:
+        cl_body = None
+        # Try the agency-specific path first so we pick up the right version,
+        # then fall back to the wildcard agency.
+        for cl_path in (
+            f"structure/codelist/{cl['agency']}/{cl['id']}/+",
+            f"structure/codelist/all/{cl['id']}/+",
+        ):
+            try:
+                cl_body = _download_parse(cl_path, times=times)
+                break
+            except ValueError:
+                continue
+        memo[cl_key] = cl_body
+
+    if cl_body is None:
+        return empty_ref, []
+
+    clists = cl_body.get("data", {}).get("codelists", [])
+    if not clists:
+        return empty_ref, []
+
+    codes = clists[0].get("codes", []) or []
+    if not codes:
+        return empty_ref, []
+
+    return (
+        {
+            "id": cl["id"],
+            "agency": cl["agency"],
+            "version": _extract_first(clists[0].get("version")) or cl.get("version"),
+            "name": _extract_first(clists[0].get("name")) or cl["id"],
+        },
+        codes,
+    )
+
+
+def _dsd_component_rows(
+    dataflow_id: str,
+    times: int = 3,
+    include_time: bool = False,
+    include_measures: bool = False,
+    flow_row: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """
+    (Internal) List a dataflow's datastructure components in positional order.
+
+    Args:
+        dataflow_id (str): The ID of the dataflow.
+        times (int, optional): The number of times to retry each request.
+            Defaults to 3.
+        include_time (bool, optional): Whether to include time dimensions.
+        include_measures (bool, optional): Whether to include measures.
+        flow_row (dict, optional): Pre-fetched dataflow object, to avoid a
+            redundant catalog request when the caller already has one.
+
+    Returns:
+        list: Dicts with ``dimension_id``, ``type``, ``position``, and the raw
+        ``component`` object. Dimensions come first, in DSD position order,
+        followed by time dimensions and then measures.
+    """
+    components = _get_datastructure_components(dataflow_id, times, flow_row=flow_row)
+    dimension_list = components.get("dimensionList", {}) or {}
+
+    def _rows(items: list[Any] | None, default_type: str) -> list[dict[str, Any]]:
+        collected = []
+        for item in items or []:
+            if not item:
+                continue
+            dim_id = _extract_first(item.get("id"))
+            if not dim_id:
+                continue
+            position = item.get("position")
+            collected.append(
+                {
+                    "dimension_id": dim_id,
+                    "type": _extract_first(item.get("type")) or default_type,
+                    "position": int(position) if position is not None else None,
+                    "component": item,
+                }
+            )
+        return collected
+
+    rows = _rows(dimension_list.get("dimensions"), "Dimension")
+    # Components without a declared position sort last rather than blowing up.
+    rows.sort(key=lambda row: (row["position"] is None, row["position"] or 0))
+
+    if include_time:
+        rows.extend(_rows(dimension_list.get("timeDimensions"), "TimeDimension"))
+
+    if include_measures:
+        measure_list = components.get("measureList", {}) or {}
+        rows.extend(_rows(measure_list.get("measures"), "Measure"))
+
+    if not rows:
+        raise ValueError(f"No dimensions found for database {dataflow_id}.")
+
+    return rows
+
+
 def _imf_dimensions(
     database_id: str, times: int = 3, inputs_only: bool = True
 ) -> DataFrame:
@@ -510,219 +730,292 @@ def _imf_dimensions(
         pandas.DataFrame: A DataFrame containing the parameter names and their
         corresponding codes and descriptions.
     """
-    # Get DSD components
-    components = _get_datastructure_components(database_id, times)
+    memo: dict[str, Any] = {}
+    rows = _dsd_component_rows(
+        database_id,
+        times=times,
+        include_time=not inputs_only,
+        include_measures=not inputs_only,
+    )
 
-    # Extract dimensions from dimensionList
-    dimension_list = components.get("dimensionList", {})
-    dimensions = dimension_list.get("dimensions", [])
-    time_dimensions = dimension_list.get("timeDimensions", [])
-
-    # Extract measures from measureList (only when inputs_only=False)
-    measures = []
-    if not inputs_only:
-        measure_list = components.get("measureList", {})
-        measures = measure_list.get("measures", [])
-
-    # Combine dimensions (always), time dimensions (only if inputs_only=False),
-    # and measures (only if inputs_only=False)
-    dims_to_process = []
-    time_dim_ids = set()
-    measure_ids = set()
-
-    # Regular dimensions
-    for d in dimensions:
-        if d is not None:
-            dims_to_process.append(("dimension", d))
-
-    # Time dimensions (only if inputs_only=False)
-    if not inputs_only:
-        for d in time_dimensions:
-            if d is not None:
-                dim_id = _extract_first(d.get("id"))
-                if dim_id:
-                    time_dim_ids.add(dim_id)
-                dims_to_process.append(("time_dimension", d))
-
-        # Measures (only if inputs_only=False)
-        for d in measures:
-            if d is not None:
-                dim_id = _extract_first(d.get("id"))
-                if dim_id:
-                    measure_ids.add(dim_id)
-                dims_to_process.append(("measure", d))
-
-    if not dims_to_process:
-        raise ValueError(f"No dimensions found for database {database_id}.")
-
-    # Build dimension map: dimension_id -> conceptIdentity, local enumeration, and type
-    dim_map: dict[str, dict[str, Any]] = {}
-    for source_type, dim in dims_to_process:
-        dim_id = _extract_first(dim.get("id"))
-        concept_identity = _extract_first(dim.get("conceptIdentity"))
-        dim_type = _extract_first(dim.get("type"))
-        local_enum = None
-        try:
-            local_rep = dim.get("localRepresentation", {})
-            if local_rep:
-                local_enum = _extract_first(local_rep.get("enumeration"))
-        except (AttributeError, KeyError, TypeError):
-            pass
-
-        dim_map[dim_id] = {
-            "concept_identity": concept_identity,
-            "local_enum": local_enum,
-            "type": dim_type,
-            "is_time_dimension": dim_id in time_dim_ids,
-            "is_measure": dim_id in measure_ids,
-        }
-
-    # For each dimension, resolve its codelist and get codes
     params = []
     codes = []
     agencies = []
     descriptions = []
+    seen = set()
 
-    for dim_id, dim_info in dim_map.items():
-        concept_identity = dim_info["concept_identity"]
-        local_enum = dim_info["local_enum"]
-        dim_type = dim_info["type"]
-        is_time_dimension = dim_info["is_time_dimension"]
-        is_measure = dim_info["is_measure"]
+    for row in rows:
+        dim_id = row["dimension_id"]
+        if dim_id in seen:
+            continue
+        seen.add(dim_id)
 
-        # Try to resolve codelist for this dimension/measure
-        codelist_id = None
-        codelist_agency = None
-        codelist_name = None
+        ref, _codes = _component_codelist(row["component"], times=times, memo=memo)
+        codelist_id = ref["id"]
+        codelist_name = ref["name"]
 
-        if concept_identity:
-            # Parse concept URN to get concept scheme info
-            cref = _parse_concept_urn(concept_identity)
-            if cref.get("agency") and cref.get("scheme") and cref.get("concept"):
-                # Fetch concept scheme to find enumeration
-                cs_paths = [
-                    f"structure/conceptscheme/{cref['agency']}/{cref['scheme']}/+",
-                    f"structure/conceptscheme/all/{cref['scheme']}/+",
-                ]
-
-                cs_body = None
-                for cs_path in cs_paths:
-                    try:
-                        cs_body = _download_parse(cs_path, times=times)
-                        break
-                    except ValueError:
-                        continue
-
-                if cs_body is not None:
-                    # Find the concept in the concept scheme
-                    cs_list = cs_body.get("data", {}).get("conceptSchemes", [])
-                    concept = None
-                    for cs in cs_list:
-                        cands = cs.get("concepts", [])
-                        if not cands:
-                            continue
-                        for cn in cands:
-                            cn_id = _extract_first(cn.get("id"))
-                            if cn_id == cref["concept"]:
-                                concept = cn
-                                break
-                        if concept:
-                            break
-
-                    # Get enumeration from concept or fall back to local enum
-                    enum_from_concept = None
-                    if concept:
-                        core_rep = concept.get("coreRepresentation", {})
-                        if core_rep:
-                            enum_from_concept = _extract_first(
-                                core_rep.get("enumeration")
-                            )
-
-                    enum_urn = enum_from_concept if enum_from_concept else local_enum
-                else:
-                    # If concept scheme not found, try local enum directly
-                    enum_urn = local_enum
-            else:
-                # If concept URN parsing fails, try to use local enum directly
-                enum_urn = local_enum
-
-            # Try to parse and fetch codelist if we have an enum URN
-            if enum_urn:
-                cl = _parse_codelist_urn(enum_urn)
-                if cl.get("agency") and cl.get("id"):
-                    # Fetch codelist - try agency-specific path first to get the correct version,
-                    # then fall back to 'all' if the agency path fails
-                    cl_paths = [
-                        f"structure/codelist/{cl['agency']}/{cl['id']}/+",
-                        f"structure/codelist/all/{cl['id']}/+",
-                    ]
-
-                    cl_body = None
-                    for cl_path in cl_paths:
-                        try:
-                            cl_body = _download_parse(cl_path, times=times)
-                            break
-                        except ValueError:
-                            continue
-
-                    if cl_body is not None:
-                        clists = cl_body.get("data", {}).get("codelists", [])
-                        if clists and len(clists) > 0:
-                            codes_list = clists[0].get("codes", [])
-                            if codes_list:
-                                # Extract codelist ID and agency for the code column
-                                codelist_id = cl["id"]
-                                codelist_agency = cl["agency"]
-
-                                # Get codelist name/description from codelist metadata
-                                codelist_name = _extract_first(clists[0].get("name"))
-                                if not codelist_name:
-                                    # Fallback to codelist ID if no name available
-                                    codelist_name = codelist_id
-
-        # Add parameter (always add, even if no codelist found)
-        # For inputs_only=True, skip dimensions without codelists
-        # For inputs_only=False, include all dimensions/measures even without codelists
+        # Enumerated dimensions are the only ones usable as request filters.
         if inputs_only and codelist_id is None:
             continue
 
-        # For time dimensions and measures without codelists, use their ID as the code
-        # but leave description as None (this matches the expected behavior where
-        # only descriptions are NA, not codes)
-        if codelist_id is None and not inputs_only:
-            # Check if this is a time dimension or measure
-            if (
-                is_time_dimension
-                or is_measure
-                or dim_type in ("TimeDimension", "Measure")
-            ):
-                codelist_id = dim_id.lower()
-                # Ensure description is None (not a string)
-                codelist_name = None
+        # Time dimensions and measures are never enumerated; surface them under
+        # their own ID so callers can still see that they exist.
+        if codelist_id is None and row["type"] in ("TimeDimension", "Measure"):
+            codelist_id = dim_id.lower()
+            codelist_name = None
 
         params.append(dim_id.lower())
         codes.append(codelist_id)
-        agencies.append(codelist_agency)
+        agencies.append(ref["agency"])
         descriptions.append(codelist_name)
 
-    # Build DataFrames
     param_code_df = DataFrame({"parameter": params, "code": codes, "agency": agencies})
 
-    # Create codelist description DataFrame
-    # Filter out None codes before creating codelist_df to avoid duplicates with None
+    # Build the code -> description lookup from enumerated components only, so
+    # that unenumerated components do not collide on a None key.
     codelist_df = DataFrame(
         {
             "code": [c for c in codes if c is not None],
             "description": [d for c, d in zip(codes, descriptions) if c is not None],
         }
     )
-    # Remove duplicates while preserving order
     codelist_df = codelist_df.drop_duplicates(subset=["code"], keep="first")
 
-    # Use left join to keep all parameters and fill in descriptions where available
+    # Left join so parameters without a description are kept.
     result_df = param_code_df.merge(codelist_df, on="code", how="left")
 
     return result_df
+
+
+_PERIOD_FREQ_SUFFIX = re.compile(r"^\d{4}-(M|Q|A|W)\d+$")
+_PERIOD_MONTH = re.compile(r"^\d{4}-\d{2}$")
+_PERIOD_YEAR = re.compile(r"^\d{4}$")
+
+
+def _transform_period_for_frequency(
+    period: str | None,
+    frequency: list[str] | None,
+    bound: Literal["start", "end"] = "start",
+) -> str | None:
+    """Transform a user time period into the SDMX filter form for a frequency.
+
+    When ``frequency`` is a single code, year bounds use that frequency's first
+    (start) or last (end) period of the year. When frequency is omitted or
+    multi-valued, start uses the earliest cross-frequency suffix (``-A1``) and
+    end uses a high sentinel (``-W99``) so quarterly/monthly periods in the
+    requested year are not excluded by lexicographic comparison.
+    """
+    if not period:
+        return period
+    if _PERIOD_FREQ_SUFFIX.match(period):
+        return period
+    if _PERIOD_MONTH.match(period):
+        year, month = period.split("-")
+        return f"{year}-M{month}"
+    if _PERIOD_YEAR.match(period):
+        start_suffixes = {"A": "-A1", "Q": "-Q1", "M": "-M01", "W": "-W01"}
+        end_suffixes = {"A": "-A1", "Q": "-Q4", "M": "-M12", "W": "-W53"}
+        if frequency and len(frequency) == 1:
+            freq = frequency[0].upper()
+            suffix_map = end_suffixes if bound == "end" else start_suffixes
+            suffix = suffix_map.get(freq, "-A1" if bound == "start" else "-W99")
+        else:
+            suffix = "-A1" if bound == "start" else "-W99"
+        return f"{period}{suffix}"
+    return period
+
+
+def _build_time_query_params(
+    start_period: str | None,
+    end_period: str | None,
+    user_frequency: list[str] | None,
+    provider_agency: str,
+) -> dict[str, str]:
+    """
+    (Internal) Build the query parameters for a data request, including the
+    time window when the publishing agency supports server-side filtering.
+    """
+    query_params = {
+        "dimensionAtObservation": "TIME_PERIOD",
+        "attributes": "dsd",
+        "measures": "all",
+    }
+    time_filters = []
+    if start_period:
+        start = _transform_period_for_frequency(
+            start_period, user_frequency, bound="start"
+        )
+        time_filters.append(f"ge:{start}")
+    if end_period:
+        end = _transform_period_for_frequency(end_period, user_frequency, bound="end")
+        time_filters.append(f"le:{end}")
+    if time_filters:
+        if provider_agency == "IMF.STA":
+            query_params["c[TIME_PERIOD]"] = "+".join(time_filters)
+        else:
+            warn(
+                f"Agency {provider_agency} does not support time filters; "
+                "time window will be ignored."
+            )
+    return query_params
+
+
+def _build_data_request(
+    dataflow_id: str,
+    dimension_filters: dict[str, list[str]],
+    start_period: str | None = None,
+    end_period: str | None = None,
+    times: int = 3,
+    flow_row: dict[str, Any] | None = None,
+) -> tuple[str, dict[str, str]]:
+    """
+    (Internal) Build the resource path and query parameters for a data request.
+
+    The series key is positional: each dimension in the datastructure occupies
+    one dot-separated slot, in DSD position order, and a slot is wildcarded with
+    ``*`` when the caller supplied no codes for it. Multiple codes for one
+    dimension are joined with ``+``.
+
+    Args:
+        dataflow_id (str): The ID of the dataflow to query.
+        dimension_filters (dict): Maps upper-cased dimension IDs to lists of
+            codes. Dimensions absent from the dict are wildcarded.
+        start_period (str, optional): Lower bound on the time period.
+        end_period (str, optional): Upper bound on the time period.
+        times (int, optional): The number of times to retry each request.
+        flow_row (dict, optional): Pre-fetched dataflow object. Supplying it
+            keeps the whole request to a single catalog lookup.
+
+    Returns:
+        tuple: ``(data_path, query_params)``.
+
+    Raises:
+        ValueError: If a requested dimension is not part of the datastructure.
+    """
+    # One catalog lookup serves both DSD resolution and provider agency.
+    if flow_row is None:
+        flow_row = _find_dataflow(dataflow_id, times=times)
+
+    rows = _dsd_component_rows(dataflow_id, times=times, flow_row=flow_row)
+    key_rows = [row for row in rows if row["type"] != "TimeDimension"]
+
+    available_dims = {row["dimension_id"].upper() for row in key_rows}
+    unknown = set(dimension_filters) - available_dims
+    if unknown:
+        raise ValueError(
+            f"Unknown dimension(s): {', '.join(sorted(unknown))}. "
+            f"Available dimensions: {', '.join(sorted(available_dims))}"
+        )
+
+    segments = []
+    for row in key_rows:
+        codes = dimension_filters.get(row["dimension_id"].upper(), [])
+        segments.append("+".join(codes) if codes else "*")
+    key = ".".join(segments)
+
+    # A bare year is expanded using the requested frequency, so find whichever
+    # frequency dimension this datastructure happens to use.
+    freq_dim_id = next((d for d in ("FREQUENCY", "FREQ") if d in available_dims), None)
+    user_frequency = dimension_filters.get(freq_dim_id) if freq_dim_id else None
+
+    provider_agency = _extract_first(flow_row.get("agencyID")) or "all"
+
+    query_params = _build_time_query_params(
+        start_period, end_period, user_frequency, provider_agency
+    )
+
+    return f"data/dataflow/{provider_agency}/{dataflow_id}/+/{key}", query_params
+
+
+def _parse_imf_sdmx_json(message: dict[str, Any]) -> DataFrame:
+    """
+    (Internal) Flatten an SDMX-JSON data message into one row per observation.
+
+    The message stores observations under compact numeric keys: a series key
+    like ``"0:3:1"`` indexes into each dimension's value list, and each
+    observation key indexes into the time dimension's value list. Both are
+    expanded back into codes here.
+
+    Args:
+        message (dict): The parsed JSON response from the API.
+
+    Returns:
+        pandas.DataFrame: One row per observation, with a column per series
+        dimension plus TIME_PERIOD and OBS_VALUE. Empty if the message carries
+        no observations.
+    """
+    if not message or not message.get("data"):
+        return DataFrame()
+
+    data_sets = message.get("data", {}).get("dataSets")
+    structures = message.get("data", {}).get("structures")
+
+    if not data_sets or not structures:
+        return DataFrame()
+
+    ds = data_sets[0]
+    st = structures[0]
+
+    series_dims = st.get("dimensions", {}).get("series", [])
+    obs_dims = st.get("dimensions", {}).get("observation", [])
+    obs_dim = obs_dims[0] if obs_dims else None
+
+    def index_to_value(
+        dim_def: dict[str, Any] | None, idx: Any, keys: tuple[str, ...]
+    ) -> Any:
+        """Look up a dimension value by its positional index."""
+        if not dim_def or not dim_def.get("values"):
+            return None
+        try:
+            i = int(idx)
+        except (ValueError, TypeError):
+            return None
+        values = dim_def["values"]
+        if i < 0 or i >= len(values):
+            return None
+        entry = values[i]
+        for k in keys:
+            if entry.get(k) is not None:
+                return entry[k]
+        return None
+
+    if not ds.get("series"):
+        return DataFrame()
+
+    series_dim_ids = [_extract_first(dim.get("id")) for dim in series_dims or []]
+
+    rows = []
+    for series_key, series in ds["series"].items():
+        observations = series.get("observations", {})
+        if not observations:
+            continue
+
+        key_parts: list[Any] = series_key.split(":")
+        # Pad so a short key still lines up with the dimension list.
+        if len(key_parts) < len(series_dim_ids):
+            key_parts.extend([None] * (len(series_dim_ids) - len(key_parts)))
+
+        series_codes = [
+            index_to_value(dim_def, idx, ("id", "value")) if idx is not None else None
+            for dim_def, idx in zip(series_dims or [], key_parts)
+        ]
+
+        for obs_key, obs in observations.items():
+            raw_value = obs[0] if obs else None
+            obs_value = None
+            if raw_value is not None:
+                try:
+                    obs_value = float(raw_value)
+                except (ValueError, TypeError):
+                    # Non-numeric missing-value flags stay None.
+                    obs_value = None
+
+            row = dict(zip(series_dim_ids, series_codes))
+            row["TIME_PERIOD"] = index_to_value(obs_dim, obs_key, ("value", "id"))
+            row["OBS_VALUE"] = obs_value
+            rows.append(row)
+
+    return DataFrame(rows) if rows else DataFrame()
 
 
 def _imf_metadata(database_id: str, times: int = 3) -> dict[str, Any]:
@@ -768,12 +1061,7 @@ def _imf_metadata(database_id: str, times: int = 3) -> dict[str, Any]:
     dataflow = dataflows[0] if dataflows else {}
 
     # Find lastUpdatedAt from annotations
-    last_updated = None
-    annotations = dataflow.get("annotations", [])
-    for ann in annotations:
-        if ann.get("id") == "lastUpdatedAt":
-            last_updated = ann.get("value")
-            break
+    last_updated = _annotation_value(dataflow, "lastUpdatedAt")
 
     # Build output similar to old format but adapted for new API
     output = {

--- a/imfp/utils.py
+++ b/imfp/utils.py
@@ -21,6 +21,58 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
+# --- Argument validation -----------------------------------------------------
+#
+# Public functions validate their own arguments rather than relying on a runtime
+# enforcement decorator. Most callers reach this library from notebooks and never
+# run a type checker, so a bad argument needs to fail at the call site with a
+# message naming the argument. Wrong type raises TypeError; a value of the right
+# type that is out of range raises ValueError.
+
+
+def _require_str(value: Any, name: str) -> str:
+    """Return ``value`` if it is a string, else raise TypeError naming ``name``."""
+    if not isinstance(value, str):
+        raise TypeError(
+            f"{name} must be a string; got {type(value).__name__} ({value!r})."
+        )
+    return value
+
+
+def _require_bool(value: Any, name: str) -> bool:
+    """Return ``value`` if it is a bool, else raise TypeError naming ``name``."""
+    if not isinstance(value, bool):
+        raise TypeError(
+            f"{name} must be True or False; got {type(value).__name__} ({value!r})."
+        )
+    return value
+
+
+def _require_int(value: Any, name: str, minimum: int | None = None) -> int:
+    """
+    Return ``value`` if it is an int (and at least ``minimum``, when given).
+
+    ``bool`` is rejected even though it subclasses ``int``: passing True where a
+    retry count belongs is a mistake, not a request for one attempt.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(
+            f"{name} must be an integer; got {type(value).__name__} ({value!r})."
+        )
+    if minimum is not None and value < minimum:
+        raise ValueError(f"{name} must be at least {minimum}; got {value}.")
+    return value
+
+
+def _require_number(value: Any, name: str) -> int | float:
+    """Return ``value`` if it is a real number, else raise TypeError."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(
+            f"{name} must be a number; got {type(value).__name__} ({value!r})."
+        )
+    return value
+
+
 def _min_wait_time_limited(
     default_wait_time: float = 1.5,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:

--- a/index.qmd
+++ b/index.qmd
@@ -6,7 +6,13 @@
 
 `imfp`, created and maintained by [Promptly Technologies](https://promptlytechnologies.com), is a Python package for downloading data from the [International Monetary Fund's](http://data.imf.org/) [RESTful JSON API](http://datahelp.imf.org/knowledgebase/articles/667681-using-json-restful-web-service).
 
-**NOTE: The IMF recently discontinued their SDMX 2.0 API, which `imfp` used, and migrated to 3.0. Version 1.3.0 of `imfp` represents my best effort to make a semi-backward compatible version of the library. Function names remain the same, and I have added a few helpers to map old parameters to the new ones. But the honest truth is that the structure of the API and the data returned by it has changed very significantly, and your old code is very unlikely to work without some modifications. I apologize for the inconvenience. `imfp` version 2.0.0 will be released soon, and will rewrite the library more comprehensively to follow the patterns of the new API.**
+`imfp` follows the conventions of the [econdataverse](https://econdataverse.org/), a family of open-source packages for working with economic data in R and Python. Its API mirrors the R package [imfapi](https://github.com/Teal-Insights/r-imfapi), so the same workflow reads the same way in either language.
+
+::: {.callout-important}
+## Upgrading from imfp 1.x
+
+Version 2.0.0 replaces `imf_databases`, `imf_parameters`, `imf_parameter_defs`, and `imf_dataset` with `imf_get_dataflows`, `imf_get_datastructure`, `imf_get_codelists`, and `imf_get`. The old functions still work but now emit a `DeprecationWarning`, and will be removed in 3.0.0. See the [migration guide](user-guide/migration.qmd).
+:::
 
 ## Installation
 
@@ -24,89 +30,95 @@ import imfp
 
 ## Workflow
 
-The `imfp` package introduces four core functions: `imf_databases`, `imf_parameters`, `imf_parameter_defs`, and `imf_dataset`. The function for downloading datasets is `imf_dataset`, but you will need the other functions to determine what arguments to supply to your `imf_dataset` function call.
+Fetching data from the IMF takes four steps, one per function. Each step tells you what to pass to the next.
 
-### Fetching a List of Databases with `imf_databases`
+### 1. Find a dataset with `imf_get_dataflows`
 
-For instance, all calls to `imf_dataset` require a `database_id`. This is because the IMF serves many different databases through its API, and the API needs to know which of these many databases you're requesting data from.
-
-To fetch a list of available databases, use:
+The IMF serves hundreds of datasets, called *dataflows*, and every request has to name one. `imf_get_dataflows` lists them all:
 
 ``` {python}
-# Fetch list of available databases
-databases = imfp.imf_databases()
+dataflows = imfp.imf_get_dataflows()
+dataflows[["id", "name"]].head()
 ```
 
-See [Working with Databases](user-guide/databases.qmd) for more information.
-
-### Fetching a List of Parameters and Input Codes with `imf_parameters`
-
-Requests to fetch data from IMF databases are complicated by the fact that each database uses a different set of parameters when making a request. (At last count, there were 43 unique parameters used in making API requests from the various databases!) You also have to have the list of valid input codes for each parameter. See [Working with Parameters](user-guide/parameters.qmd) for a more detailed explanation of parameters and input codes and how they work.
-
-To obtain the full list of parameters and valid input codes for a given database, use:
+We want the Primary Commodity Price System, whose ID is `PCPS`:
 
 ``` {python}
-# Fetch list of valid parameters and input codes for commodity price database
-params = imfp.imf_parameters("PCPS")
+dataflows[dataflows["id"] == "PCPS"][["id", "name", "last_updated"]]
 ```
 
-The `imf_parameters` function returns a dictionary of data frames. Each dictionary key name corresponds to a parameter used in making requests from the database:
+See [Discovering Datasets](user-guide/databases.qmd) for more.
+
+### 2. Find its dimensions with `imf_get_datastructure`
+
+Each dataset is filtered on its own set of *dimensions*, so the next step is to ask which ones `PCPS` has:
 
 ``` {python}
-# Get key names from the params object
-params.keys()
+dimensions = imfp.imf_get_datastructure("PCPS")
+dimensions
 ```
 
-Each named list item is a data frame containing the valid input codes (and their descriptions) that can be used with the named parameter.
+### 3. Find valid codes with `imf_get_codelists`
 
-To access the data frame containing valid values for each parameter, subset the `params` dict by the parameter name:
+Dimensions are categorical: each accepts a fixed set of *codes*. `imf_get_codelists` returns them as a tidy DataFrame:
 
 ``` {python}
-# View the data frame of valid input codes for the frequency parameter
-params['frequency']
+codes = imfp.imf_get_codelists(["INDICATOR", "DATA_TRANSFORMATION", "FREQUENCY"], "PCPS")
+codes.head()
 ```
 
-### Supplying Parameter Arguments to `imf_dataset`
-
-To make a request to fetch data from the IMF API, just call `imfp.imf_dataset` with the database ID and keyword arguments for each parameter, where the keyword argument name is the parameter name and the value is the list of codes you want.
-
-For instance, on exploring the `frequency` parameter of the Primary Commodity Price System database above, we found that the frequency can take one of three values: "A" for annual, "Q" for quarterly, and "M" for monthly. Thus, to request annual data, we can call `imfp.imf_dataset` with `frequency = ["A"]`.
-
-Similarly, we might search the dataframes of valid input codes for the `indicator` and `data_transformation` parameters to find the input codes for coal and index:
+Because the result is one DataFrame, finding the code you want is an ordinary pandas filter:
 
 ``` {python}
-# Find the 'indicator' input code for coal
-params['indicator'].loc[
-    params['indicator']['description'].str.contains("Coal")
-]
+# Find the indicator code for coal
+codes[
+    (codes["dimension_id"] == "INDICATOR")
+    & codes["name"].str.contains("Coal index", na=False)
+][["code", "name"]]
 ```
 
 ``` {python}
-# Find the 'data_transformation' input code for index
-params['data_transformation'].loc[
-    params['data_transformation']['description'].str.contains("Index")
-]
+# Find the data transformation code for an index
+codes[
+    (codes["dimension_id"] == "DATA_TRANSFORMATION")
+    & codes["name"].str.contains("Index", na=False)
+][["code", "name"]]
 ```
 
-Finally, we can use the information we've gathered to make the request to fetch the data:
+See [Dimensions and Codes](user-guide/parameters.qmd) for more.
+
+### 4. Fetch the data with `imf_get`
+
+Now pass those codes to `imf_get`. Dimensions you leave out are wildcarded:
 
 ``` {python}
-# Request data from the API
-df = imfp.imf_dataset(database_id = "PCPS",
-         frequency = ["A"], indicator = ["PCOAL"],
-         data_transformation = ["INDEX"])
+df = imfp.imf_get(
+    "PCPS",
+    dimensions={
+        "INDICATOR": ["PCOAL"],
+        "DATA_TRANSFORMATION": ["INDEX"],
+        "FREQUENCY": ["A"],
+    },
+)
 
-# Display the first few entries in the retrieved data frame
 df.head()
 ```
 
-## Working with the Returned Data Frame
-
-Note that all columns in the returned data frame are string objects, and to plot the series we will need to convert to valid numeric or date formats:
+Dimensions can also be passed as keyword arguments, which is terser for short queries:
 
 ``` {python}
-# Convert obs_value to numeric and time_period to integer year
-df = df.astype({"time_period" : int, "obs_value" : float})
+#| eval: false
+df = imfp.imf_get("PCPS", indicator="PCOAL", data_transformation="INDEX", frequency="A")
+```
+
+See [Fetching Data](user-guide/datasets.qmd) for more.
+
+## Working with the Returned Data Frame
+
+`imf_get` returns tidy data: one observation per row, one variable per column. `OBS_VALUE` is already numeric, but `TIME_PERIOD` is a string, because its format depends on the frequency of the series ("2000" for annual data, "2000-Q1" for quarterly, "2000-M01" for monthly). For an annual series it converts directly:
+
+``` {python}
+df = df.astype({"TIME_PERIOD": int})
 ```
 
 Then, using `seaborn` with `hue`, we can plot different indicators in different colors:
@@ -115,7 +127,7 @@ Then, using `seaborn` with `hue`, we can plot different indicators in different 
 import seaborn as sns
 
 # Plot prices of different commodities in different colors with seaborn
-sns.lineplot(data=df, x='time_period', y='obs_value', hue='indicator');
+sns.lineplot(data=df, x="TIME_PERIOD", y="OBS_VALUE", hue="INDICATOR");
 ```
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "imfp"
-version = "1.3.4"
-description = "Python package for downloading economic data from the International Monetary Fund JSON RESTful API endpoint."
+version = "2.0.0"
+description = "Python package for downloading economic data from the International Monetary Fund SDMX 3.0 API, following econdataverse conventions."
 authors = [
     {name = "Christopher C. Smith", email = "christopher.smith@promptlytechnologies.com"}
 ]
 license = {file = "LICENSE"}
 readme = "README.md"
-keywords = ["economics", "finance", "IMF", "API"]
+keywords = ["economics", "finance", "IMF", "API", "SDMX", "econdataverse"]
 classifiers = [
     "Intended Audience :: Financial and Insurance Industry",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ requires-python = ">=3.10"
 dependencies = [
     "pandas == 2.2.3",
     "requests==2.33.0",
-    "type-enforced>=1.10.1",
 ]
 
 [project.urls]

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -16,11 +16,11 @@ def test_set_imf_app_name():
         set_imf_app_name("imfp")
 
     with pytest.raises(TypeError):
-        set_imf_app_name(None)
+        set_imf_app_name(None)  # ty: ignore[invalid-argument-type]
     with pytest.raises(TypeError):
-        set_imf_app_name(float("nan"))
+        set_imf_app_name(float("nan"))  # ty: ignore[invalid-argument-type]
     with pytest.raises(TypeError):
-        set_imf_app_name(["z", "z"])
+        set_imf_app_name(["z", "z"])  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(ValueError):
         set_imf_app_name("z" * 256)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -305,21 +305,21 @@ def test_imf_get_rejects_dataframe_codes(set_options, use_saved_responses):
     """imf_parameters passed DataFrames around; imf_get takes plain codes."""
     codes = imf_get_codelists("COUNTRY", "GFS_SOO")
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(TypeError) as excinfo:
         imf_get("GFS_SOO", country=codes)
 
     assert "imf_get_codelists" in str(excinfo.value)
 
 
 def test_imf_get_rejects_non_string_codes(set_options, use_saved_responses):
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         imf_get("GFS_SOO", country=[123])
 
 
 def test_imf_get_rejects_malformed_periods(set_options, use_saved_responses):
     # A list is caught by the signature's type enforcement.
     with pytest.raises(TypeError):
-        imf_get("GFS_SOO", country="ABW", start_period=[1999, 2004])
+        imf_get("GFS_SOO", country="ABW", start_period=[1999, 2004])  # ty: ignore[no-matching-overload]
 
     with pytest.raises(ValueError):
         imf_get("GFS_SOO", country="ABW", end_period="   ")
@@ -388,3 +388,95 @@ def test_legacy_imf_dataset_warns(set_options, use_saved_responses):
         )
 
     assert any("imf_get" in str(w.message) for w in record)
+
+
+# ---------------------------------------------------------------------------
+# Argument validation
+#
+# The package validates its own arguments rather than using a runtime
+# enforcement decorator, so the checks below are testing our code, not a
+# third-party library's.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: imf_get_dataflows(max_tries="3"),  # ty: ignore[invalid-argument-type]
+        lambda: imf_get_datastructure(123),  # ty: ignore[invalid-argument-type]
+        lambda: imf_get_datastructure("GFS_SOO", max_tries=None),  # ty: ignore[invalid-argument-type]
+        lambda: imf_get_datastructure("GFS_SOO", include_time="yes"),  # ty: ignore[invalid-argument-type]
+        lambda: imf_get_datastructure("GFS_SOO", include_measures=1),  # ty: ignore[invalid-argument-type]
+        lambda: imf_get_codelists("COUNTRY", 123),  # ty: ignore[invalid-argument-type]
+        lambda: imf_get_codelists(123, "GFS_SOO"),  # ty: ignore[invalid-argument-type]
+        lambda: imf_get_codelists(["COUNTRY", 7], "GFS_SOO"),  # ty: ignore[invalid-argument-type]
+        lambda: imf_get(123),  # ty: ignore[no-matching-overload]
+        lambda: imf_get("GFS_SOO", max_tries=1.5),  # ty: ignore[no-matching-overload]
+        lambda: imf_get("GFS_SOO", print_url="yes"),  # ty: ignore[no-matching-overload]
+        lambda: imf_get("GFS_SOO", return_raw="yes"),  # ty: ignore[no-matching-overload]
+        lambda: imf_get("GFS_SOO", dimensions=["COUNTRY"]),  # ty: ignore[no-matching-overload]
+        lambda: imf_get("GFS_SOO", country="ABW", start_period=[1999, 2004]),  # ty: ignore[no-matching-overload]
+    ],
+)
+def test_bad_argument_types_raise_type_error(set_options, call):
+    with pytest.raises(TypeError):
+        call()
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: imf_get_dataflows(max_tries=0),
+        lambda: imf_get_datastructure("GFS_SOO", max_tries=0),
+        lambda: imf_get("GFS_SOO", max_tries=0),
+        lambda: imf_get("GFS_SOO", country="ABW", end_period="   "),
+    ],
+)
+def test_out_of_range_arguments_raise_value_error(set_options, call):
+    with pytest.raises(ValueError):
+        call()
+
+
+def test_validation_errors_name_the_argument(set_options):
+    """A bad argument should say which one, so the fix is obvious."""
+    with pytest.raises(TypeError) as excinfo:
+        imf_get_datastructure("GFS_SOO", max_tries="3")  # ty: ignore[invalid-argument-type]
+    assert "max_tries" in str(excinfo.value)
+
+    with pytest.raises(TypeError) as excinfo:
+        imf_get(123)  # ty: ignore[no-matching-overload]
+    assert "dataflow_id" in str(excinfo.value)
+
+
+def test_validation_happens_before_any_request(set_options):
+    """Bad arguments must fail without the fixture-less network being touched."""
+    # No use_saved_responses fixture here: if validation let these through to a
+    # request, the call would fail with a connection error rather than TypeError.
+    with pytest.raises(TypeError):
+        imf_get_datastructure(123)  # ty: ignore[invalid-argument-type]
+    with pytest.raises(TypeError):
+        imf_get_codelists("COUNTRY", 123)  # ty: ignore[invalid-argument-type]
+
+
+def test_legacy_functions_validate_their_arguments(set_options):
+    """The deprecated functions kept their argument checks after the decorator went."""
+    with pytest.raises(TypeError):
+        imf_databases(times="3")  # ty: ignore[invalid-argument-type]
+    with pytest.raises(TypeError):
+        imf_parameters(123)  # ty: ignore[invalid-argument-type]
+    with pytest.raises(TypeError):
+        imf_parameter_defs("BOP", inputs_only="yes")  # ty: ignore[invalid-argument-type]
+    with pytest.raises(ValueError):
+        imf_parameters("BOP", times=0)
+
+
+def test_legacy_imf_dataset_validates_its_arguments(set_options):
+    """imf_dataset never had the decorator; it leaned on imf_parameters for checks."""
+    with pytest.raises(TypeError):
+        imf_dataset(database_id=2)  # ty: ignore[no-matching-overload]
+    with pytest.raises(TypeError):
+        imf_dataset(database_id=["a", "b"])  # ty: ignore[no-matching-overload]
+    with pytest.raises(TypeError):
+        imf_dataset(database_id="PCPS", parameters=["not", "a", "dict"])  # ty: ignore[no-matching-overload]
+    with pytest.raises(TypeError):
+        imf_dataset(database_id="PCPS", include_metadata="yes")  # ty: ignore[no-matching-overload]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,390 @@
+"""Tests for the econdataverse-style API in imfp.api.
+
+Like the rest of the suite these run fully offline: conftest's
+``use_saved_responses`` fixture replays cached JSON keyed by the SHA256 of the
+request URL, so a test that changes the URL a function builds will fail loudly
+rather than hit the network.
+"""
+
+import os
+import warnings
+
+import pandas as pd
+import pytest
+
+from imfp import (
+    imf_databases,
+    imf_dataset,
+    imf_get,
+    imf_get_codelists,
+    imf_get_dataflows,
+    imf_get_datastructure,
+    imf_parameter_defs,
+    imf_parameters,
+    set_imf_wait_time,
+)
+from imfp.utils import _imf_save_response, _imf_use_cache
+
+
+@pytest.fixture
+def set_options(monkeypatch):
+    """Disable rate limiting and response capture for the duration of a test."""
+    original_save_response = _imf_save_response
+    original_use_cache = _imf_use_cache
+    original_wait_time = os.environ.get("IMF_WAIT_TIME", None)
+
+    monkeypatch.setattr("imfp.utils._imf_save_response", False)
+    monkeypatch.setattr("imfp.utils._imf_use_cache", False)
+    set_imf_wait_time(0)
+
+    yield
+
+    monkeypatch.setattr("imfp.utils._imf_save_response", original_save_response)
+    monkeypatch.setattr("imfp.utils._imf_use_cache", original_use_cache)
+    if original_wait_time is not None:
+        os.environ["IMF_WAIT_TIME"] = original_wait_time
+    else:
+        os.environ.pop("IMF_WAIT_TIME", None)
+
+
+# ---------------------------------------------------------------------------
+# Step 1: imf_get_dataflows
+# ---------------------------------------------------------------------------
+
+
+def test_imf_get_dataflows(set_options, use_saved_responses):
+    result = imf_get_dataflows()
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == [
+        "id",
+        "name",
+        "description",
+        "version",
+        "agency",
+        "structure",
+        "last_updated",
+    ]
+    assert len(result) > 0
+    assert result["id"].notna().all()
+    assert not result["id"].duplicated().any()
+
+    # A known dataflow, with the metadata columns populated.
+    gfs = result[result["id"] == "GFS_SOO"]
+    assert len(gfs) == 1
+    assert gfs.iloc[0]["agency"] == "IMF.STA"
+    assert gfs.iloc[0]["structure"].startswith("urn:sdmx:")
+    assert gfs.iloc[0]["last_updated"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Step 2: imf_get_datastructure
+# ---------------------------------------------------------------------------
+
+
+def test_imf_get_datastructure(set_options, use_saved_responses):
+    result = imf_get_datastructure("GFS_SOO")
+
+    assert list(result.columns) == ["dimension_id", "type", "position"]
+    assert (result["type"] == "Dimension").all()
+
+    # Positions define the series key, so they must be complete and ordered.
+    assert result["position"].notna().all()
+    assert list(result["position"]) == sorted(result["position"])
+
+    assert "COUNTRY" in set(result["dimension_id"])
+    # GFS_SOO spells frequency out in full; the package must not assume "FREQ".
+    assert "FREQUENCY" in set(result["dimension_id"])
+
+
+def test_imf_get_datastructure_include_time_and_measures(
+    set_options, use_saved_responses
+):
+    base = imf_get_datastructure("GFS_SOO")
+    full = imf_get_datastructure("GFS_SOO", include_time=True, include_measures=True)
+
+    assert len(full) > len(base)
+    assert "TIME_PERIOD" in set(full["dimension_id"])
+    assert "OBS_VALUE" in set(full["dimension_id"])
+
+    types = dict(zip(full["dimension_id"], full["type"]))
+    assert types["TIME_PERIOD"] == "TimeDimension"
+    assert types["OBS_VALUE"] == "Measure"
+
+    # Measures occupy no slot in the series key.
+    positions = dict(zip(full["dimension_id"], full["position"]))
+    assert pd.isna(positions["OBS_VALUE"])
+
+
+def test_imf_get_datastructure_rejects_unknown_dataflow(
+    set_options, use_saved_responses
+):
+    with pytest.raises(ValueError):
+        imf_get_datastructure("not_a_real_dataflow", max_tries=1)
+
+
+# ---------------------------------------------------------------------------
+# Step 3: imf_get_codelists
+# ---------------------------------------------------------------------------
+
+
+def test_imf_get_codelists(set_options, use_saved_responses):
+    result = imf_get_codelists("COUNTRY", "GFS_SOO")
+
+    assert list(result.columns) == [
+        "dimension_id",
+        "code",
+        "name",
+        "description",
+        "codelist_id",
+        "codelist_agency",
+        "codelist_version",
+    ]
+    assert len(result) > 100
+    assert (result["dimension_id"] == "COUNTRY").all()
+    assert result["code"].notna().all()
+    assert result["codelist_id"].notna().all()
+    assert result["codelist_agency"].notna().all()
+    assert result["codelist_version"].notna().all()
+
+    # GFS_SOO country codes are ISO3, not the numeric IMF codes.
+    codes = set(result["code"])
+    assert {"AFG", "ALB", "DZA"}.issubset(codes)
+    assert not any(code.isdigit() for code in codes)
+
+
+def test_imf_get_codelists_accepts_multiple_dimensions(
+    set_options, use_saved_responses
+):
+    result = imf_get_codelists(["COUNTRY", "FREQUENCY"], "GFS_SOO")
+
+    by_dimension = result.groupby("dimension_id").size()
+    assert set(by_dimension.index) == {"COUNTRY", "FREQUENCY"}
+    assert by_dimension["COUNTRY"] > 100
+
+    frequencies = set(result[result["dimension_id"] == "FREQUENCY"]["code"])
+    assert {"A", "Q"}.issubset(frequencies)
+
+
+def test_imf_get_codelists_is_case_insensitive(set_options, use_saved_responses):
+    lower = imf_get_codelists("country", "GFS_SOO")
+    upper = imf_get_codelists("COUNTRY", "GFS_SOO")
+
+    # Requested case does not leak into the output.
+    assert (lower["dimension_id"] == "COUNTRY").all()
+    assert lower.equals(upper)
+
+
+def test_imf_get_codelists_rejects_unknown_dimension(set_options, use_saved_responses):
+    with pytest.raises(ValueError) as excinfo:
+        imf_get_codelists("NOT_A_DIMENSION", "GFS_SOO")
+
+    message = str(excinfo.value)
+    assert "NOT_A_DIMENSION" in message
+    # The error should point at the fix, not just the failure.
+    assert "COUNTRY" in message
+    assert "imf_get_datastructure" in message
+
+
+def test_imf_get_codelists_requires_a_dimension(set_options, use_saved_responses):
+    with pytest.raises(ValueError):
+        imf_get_codelists([], "GFS_SOO")
+
+
+# ---------------------------------------------------------------------------
+# Step 4: imf_get
+# ---------------------------------------------------------------------------
+
+GFS_SOO_QUERY = {
+    "COUNTRY": "ABW",
+    "SECTOR": "S13",
+    "GFS_GRP": "G2M",
+    "INDICATOR": ["G23_T"],
+    "TYPE_OF_TRANSFORMATION": "POGDP_PT",
+    "FREQUENCY": "A",
+}
+
+
+def test_imf_get(set_options, use_saved_responses):
+    result = imf_get(
+        "GFS_SOO",
+        dimensions=GFS_SOO_QUERY,
+        start_period=1972,
+        end_period=1976,
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+    # Dimension columns keep their SDMX IDs, then TIME_PERIOD and OBS_VALUE.
+    assert list(result.columns) == [
+        "COUNTRY",
+        "SECTOR",
+        "GFS_GRP",
+        "INDICATOR",
+        "TYPE_OF_TRANSFORMATION",
+        "FREQUENCY",
+        "TIME_PERIOD",
+        "OBS_VALUE",
+    ]
+    assert set(result["COUNTRY"]) == {"ABW"}
+    assert set(result["INDICATOR"]) == {"G23_T"}
+
+
+def test_imf_get_kwargs_match_dimensions_dict(set_options, use_saved_responses):
+    from_dict = imf_get(
+        "GFS_SOO", dimensions=GFS_SOO_QUERY, start_period=1972, end_period=1976
+    )
+    from_kwargs = imf_get(
+        "GFS_SOO",
+        country="ABW",
+        sector="S13",
+        gfs_grp="G2M",
+        indicator=["G23_T"],
+        type_of_transformation="POGDP_PT",
+        frequency="A",
+        start_period="1972",
+        end_period="1976",
+    )
+
+    assert from_dict.equals(from_kwargs)
+
+
+def test_imf_get_parses_numeric_observations(set_options, use_saved_responses):
+    result = imf_get(
+        "AFRREO", indicator=["TTT_IX", "GGX_G01_GDP_PT"], start_period=2021
+    )
+
+    assert len(result) > 1
+    assert result["OBS_VALUE"].dtype == "float64"
+    assert set(result["INDICATOR"]).issubset({"TTT_IX", "GGX_G01_GDP_PT"})
+    assert "TIME_PERIOD" in result.columns
+
+
+def test_imf_get_matches_legacy_imf_dataset(set_options, use_saved_responses):
+    """The new path must produce the same data as the function it replaces."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        legacy = imf_dataset(
+            database_id="GFS_SOO",
+            country="ABW",
+            sector="S13",
+            gfs_grp="G2M",
+            indicator=["G23_T"],
+            type_of_transformation="POGDP_PT",
+            freq="A",
+            start_year=1972,
+            end_year=1976,
+        )
+
+    new = imf_get(
+        "GFS_SOO", dimensions=GFS_SOO_QUERY, start_period=1972, end_period=1976
+    )
+
+    # imf_dataset lower-cases its columns; imf_get keeps the SDMX IDs.
+    legacy.columns = [column.upper() for column in legacy.columns]
+    assert legacy.equals(new)
+
+
+def test_imf_get_rejects_unknown_dimension(set_options, use_saved_responses):
+    with pytest.raises(ValueError) as excinfo:
+        imf_get("GFS_SOO", not_a_dimension="X")
+
+    message = str(excinfo.value)
+    assert "NOT_A_DIMENSION" in message
+    assert "COUNTRY" in message
+
+
+def test_imf_get_rejects_duplicate_dimension(set_options, use_saved_responses):
+    with pytest.raises(ValueError) as excinfo:
+        imf_get("GFS_SOO", dimensions={"COUNTRY": "ABW"}, country="ABW")
+
+    assert "more than once" in str(excinfo.value)
+
+
+def test_imf_get_rejects_dataframe_codes(set_options, use_saved_responses):
+    """imf_parameters passed DataFrames around; imf_get takes plain codes."""
+    codes = imf_get_codelists("COUNTRY", "GFS_SOO")
+
+    with pytest.raises(ValueError) as excinfo:
+        imf_get("GFS_SOO", country=codes)
+
+    assert "imf_get_codelists" in str(excinfo.value)
+
+
+def test_imf_get_rejects_non_string_codes(set_options, use_saved_responses):
+    with pytest.raises(ValueError):
+        imf_get("GFS_SOO", country=[123])
+
+
+def test_imf_get_rejects_malformed_periods(set_options, use_saved_responses):
+    # A list is caught by the signature's type enforcement.
+    with pytest.raises(TypeError):
+        imf_get("GFS_SOO", country="ABW", start_period=[1999, 2004])
+
+    with pytest.raises(ValueError):
+        imf_get("GFS_SOO", country="ABW", end_period="   ")
+
+
+def test_imf_get_warns_on_empty_result(set_options, monkeypatch):
+    """An empty response is a warning plus an empty frame, not an exception."""
+
+    def fake_download_parse(path, times=3, query_params=None, **kwargs):
+        return {"data": {"dataSets": [{"series": {}}], "structures": [{}]}}
+
+    monkeypatch.setattr("imfp.api._download_parse", fake_download_parse)
+    monkeypatch.setattr(
+        "imfp.api._build_data_request",
+        lambda *args, **kwargs: ("data/dataflow/IMF.STA/GFS_SOO/+/ABW", {}),
+    )
+
+    with pytest.warns(UserWarning, match="No observations matched"):
+        result = imf_get("GFS_SOO", country="ABW")
+
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+
+
+def test_imf_get_return_raw(set_options, use_saved_responses):
+    raw = imf_get(
+        "GFS_SOO",
+        dimensions=GFS_SOO_QUERY,
+        start_period=1972,
+        end_period=1976,
+        return_raw=True,
+    )
+
+    assert isinstance(raw, dict)
+    assert "data" in raw
+
+
+# ---------------------------------------------------------------------------
+# Deprecation of the pre-2.0 API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "call, replacement",
+    [
+        (lambda: imf_databases(), "imf_get_dataflows"),
+        (lambda: imf_parameters("GFS_SOO"), "imf_get_codelists"),
+        (lambda: imf_parameter_defs("BOP"), "imf_get_datastructure"),
+    ],
+)
+def test_legacy_functions_warn(set_options, use_saved_responses, call, replacement):
+    with pytest.warns(DeprecationWarning) as record:
+        call()
+
+    messages = [str(w.message) for w in record]
+    assert any(replacement in message for message in messages)
+    assert any("3.0.0" in message for message in messages)
+
+
+def test_legacy_imf_dataset_warns(set_options, use_saved_responses):
+    with pytest.warns(DeprecationWarning) as record:
+        imf_dataset(
+            database_id="AFRREO",
+            indicator=["TTT_IX", "GGX_G01_GDP_PT"],
+            start_year=2021,
+        )
+
+    assert any("imf_get" in str(w.message) for w in record)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -95,7 +95,7 @@ def test_imf_parameter_defs(set_options, use_saved_responses):
     )
 
     with pytest.raises(Exception):
-        imf_parameter_defs(times=1)
+        imf_parameter_defs(times=1)  # ty: ignore[missing-argument]
     with pytest.raises(Exception):
         imf_parameters("not_a_real_database", times=1)
 
@@ -112,7 +112,7 @@ def test_imf_parameters(set_options, use_saved_responses):
     # Under SDMX 3.0, frequency sets may expand. Require at least Annual and Quarterly present.
     assert {"A", "Q"}.issubset(available)
     with pytest.raises(Exception):
-        imf_parameters(times=1)
+        imf_parameters(times=1)  # ty: ignore[missing-argument]
     with pytest.raises(Exception):
         imf_parameters(database_id="not_a_real_database", times=1)
 

--- a/user-guide/databases.qmd
+++ b/user-guide/databases.qmd
@@ -1,68 +1,85 @@
 ---
-title: "Working with Databases"
+title: "Discovering Datasets"
 ---
 
-## Understanding IMF Databases
+## Dataflows
 
-The IMF serves many different databases through its API, and the API needs to know which of these many databases you're requesting data from. Before you can fetch any data, you'll need to:
+The IMF publishes hundreds of separate datasets through its API. In SDMX — the standard the API speaks — a dataset is called a **dataflow**, and every request has to name one. So before you can fetch any data, you need to:
 
-1. Get a list of available databases
-2. Find the database ID for the data you want
+1. Get the list of available dataflows
+2. Find the ID of the one you want
 
-Then you can use that database ID to fetch the data.
+That ID is the first argument to every other function in `imfp`.
 
-## Fetching the Database List
+## Listing Dataflows
 
-### Fetching an Index of Databases with the `imf_databases` Function
-
-To obtain the list of available databases and their corresponding IDs, use `imf_databases`:
+`imf_get_dataflows` returns the full catalogue as a tidy DataFrame:
 
 ``` {python}
 import imfp
 
-#Fetch the list of databases available through the IMF API
-databases = imfp.imf_databases()
-databases.head()
+dataflows = imfp.imf_get_dataflows()
+dataflows.shape
 ```
 
+Each row describes one dataset:
 
-This function returns the IMF’s listing of 71 databases available through the API.
-
-## Exploring the Database List
-
-To view and explore the database list, it’s possible to explore subsets of the data frame by row number with `databases.loc`:
+| Column | Meaning |
+|---|---|
+| `id` | The dataflow ID, e.g. `PCPS`. This is what you pass to the other functions. |
+| `name` | Human-readable title. |
+| `description` | Longer prose description, where the IMF provides one. |
+| `version` | Version of the dataflow definition. |
+| `agency` | The IMF department that publishes it, e.g. `IMF.STA`. |
+| `structure` | URN of the datastructure definition that backs it. |
+| `last_updated` | When the dataset was last refreshed. |
 
 ``` {python}
-# View a subset consisting of rows 5 through 9
-databases.loc[5:9]
+dataflows[["id", "name", "agency", "last_updated"]].head()
 ```
 
+## Finding the Dataset You Want
 
-Or, if you already know which database you want, you can fetch the corresponding code by searching for a string match using `str.contains` and subsetting the data frame for matching rows. For instance, here’s how to search for commodities data:
+Because the result is an ordinary DataFrame, searching it is an ordinary pandas filter. Search the `name` column for a keyword:
 
 ``` {python}
-databases[databases['description'].str.contains("Commodity")]
+dataflows[dataflows["name"].str.contains("Commodity", case=False, na=False)][
+    ["id", "name"]
+]
 ```
 
-See also [Working with Large Data Frames](usage.qmd#working-with-large-data-frames) for sample code showing how to view the full contents of the data frame in a browser window. 
+The `description` column often contains terms the title does not, so it is worth searching too:
 
-## Best Practices
+``` {python}
+matches = dataflows[
+    dataflows["description"].str.contains("balance of payments", case=False, na=False)
+]
+matches[["id", "name"]].head()
+```
 
-1. **Cache the Database List**: The database list rarely changes. Consider saving it locally if you'll be making multiple queries. See [Caching Strategy](rate_limits.qmd#caching-strategy) for sample code.
+## Checking How Current a Dataset Is
 
-2. **Search Strategically**: Use specific search terms to find relevant databases. For example:
+`last_updated` tells you when each dataset was last refreshed, which is useful when you are deciding whether a series is current enough for your purposes:
 
-   - "Price" for price indices
-   - "Trade" for trade statistics
-   - "Financial" for financial data
+``` {python}
+import pandas as pd
 
-3. **Use a Browser Viewer**: See [Working with Large Data Frames](usage.qmd#working-with-large-data-frames) for sample code showing how to view the full contents of the data frame in a browser window.
+recent = dataflows.dropna(subset=["last_updated"]).copy()
+recent["last_updated"] = pd.to_datetime(recent["last_updated"], format="mixed")
+recent.sort_values("last_updated", ascending=False)[["id", "name", "last_updated"]].head()
+```
 
-4. **Note Database IDs**: Once you find a database you'll use frequently, note its database ID for future reference.
+## Reading the Dataflow ID
 
-## Next Steps
+The `id` column is the value you pass everywhere else:
 
-Once you've identified the database you want to use, you'll need to:
+``` {python}
+pcps = dataflows[dataflows["id"] == "PCPS"]
+pcps[["id", "name", "agency", "version"]]
+```
 
-1. Get the list of parameters for that database (see [Parameters](parameters.qmd))
-2. Use those parameters to fetch your data (see [Datasets](datasets.qmd))
+Note the `agency`. Different IMF departments publish through the same API but do not all support the same features — in particular, only `IMF.STA` currently honors server-side time filtering. `imf_get` warns you when you ask for a time window that the publishing agency will ignore. See [Fetching Data](datasets.qmd#time-filtering).
+
+## Next Step
+
+With a dataflow ID in hand, the next step is finding out how that dataset can be filtered. See [Dimensions and Codes](parameters.qmd).

--- a/user-guide/datasets.qmd
+++ b/user-guide/datasets.qmd
@@ -1,72 +1,161 @@
 ---
-title: "Requesting Datasets"
+title: "Fetching Data"
 ---
 
 ## Making a Request
 
-To retrieve data from an IMF database, you'll need the database ID and any relevant [filter parameters](parameters.qmd). Here's a basic example using the Producer Price Index (PPI) database from 2000 to 2015:
+`imf_get` takes a dataflow ID and the dimension filters you found with [`imf_get_codelists`](parameters.qmd):
 
 ``` {python}
 import imfp
 
-# Get parameters and their valid codes
-params = imfp.imf_parameters("PPI")
+df = imfp.imf_get(
+    "PCPS",
+    dimensions={
+        "INDICATOR": ["PCOAL"],
+        "DATA_TRANSFORMATION": ["INDEX"],
+        "FREQUENCY": ["A"],
+    },
+)
+df.head()
+```
 
-# Fetch annual coal price index data
-df = imfp.imf_dataset(
-    database_id="PPI",
-    frequency=["A"],  # Annual frequency
-    indicator=["WPI"],  # Wholesale Price Index
-    type_of_transformation=["IX"],
-    start_year=2000,
-    end_year=2015
+Dimensions you do not mention are wildcarded, so the request above returns coal for every country in the dataset.
+
+## Two Ways to Pass Dimensions
+
+Filters can go in the `dimensions` dict, or in as keyword arguments, whichever reads better. Keyword names are matched case-insensitively:
+
+``` {python}
+df = imfp.imf_get("PCPS", indicator="PCOAL", data_transformation="INDEX", frequency="A")
+df.head(3)
+```
+
+A single code can be given as a bare string; several go in a list:
+
+``` {python}
+df = imfp.imf_get(
+    "PCPS",
+    indicator=["PCOAL", "PNGAS"],
+    data_transformation="INDEX",
+    frequency="A",
+)
+sorted(df["INDICATOR"].unique())
+```
+
+Passing the same dimension both ways is an error rather than a silent precedence rule:
+
+``` {python}
+try:
+    imfp.imf_get("PCPS", dimensions={"INDICATOR": "PCOAL"}, indicator="PNGAS")
+except ValueError as e:
+    print(e)
+```
+
+## The Returned Data
+
+`imf_get` returns tidy data — one observation per row, one variable per column:
+
+``` {python}
+df.dtypes
+```
+
+There is one column per dimension, named with its SDMX dimension ID, plus two more:
+
+- `TIME_PERIOD` — the period of the observation, as a string
+- `OBS_VALUE` — the observed value, as a float
+
+`OBS_VALUE` arrives already converted to `float64`, with non-numeric missing-value flags turned into `NaN`.
+
+`TIME_PERIOD` stays a string because its format depends on the frequency of the series: `"2000"` for annual data, `"2000-Q1"` for quarterly, `"2000-M01"` for monthly. See [Suggestions for Usage](usage.qmd#time-period-conversion) for conversion recipes.
+
+## Time Filtering
+
+`start_period` and `end_period` bound the time window. They accept a year, a quarter, or a month:
+
+``` {python}
+#| eval: false
+imfp.imf_get("GFS_SOO", country="ABW", frequency="A", start_period=2000, end_period=2015)
+imfp.imf_get("QNEA", country="USA", frequency="Q", start_period="2010-Q1")
+imfp.imf_get("CPI", country="USA", frequency="M", start_period="2010-01")
+```
+
+A bare year is widened to cover the whole year at the frequency you asked for: with `frequency="Q"`, `start_period=2010` means `2010-Q1` and `end_period=2015` means `2015-Q4`. When you request several frequencies at once, or none, the end bound widens far enough to keep every sub-annual period in that year.
+
+::: {.callout-warning}
+## Not every agency supports time filtering
+
+Time filtering happens server-side, and at present only datasets published by `IMF.STA` support it. For datasets published by other departments, `imf_get` warns you and returns the full time range:
+
+``` {python}
+df = imfp.imf_get(
+    "PCPS", indicator="PCOAL", data_transformation="INDEX", frequency="A",
+    start_period=2000, end_period=2015,
 )
 ```
 
-This example creates two objects we'll use in the following sections:
-
-- `params`: A dictionary of parameters and their valid codes
-- `df`: The retrieved data frame containing our requested data
-
-## Decoding Returned Data
-
-When you retrieve data using `imf_dataset`, the returned data frame contains columns that correspond to the parameters you specified in your request. However, these columns use input codes (short identifiers) rather than human-readable descriptions. To make your data more interpretable, you can replace these codes with their corresponding text descriptions using the parameter information from `imf_parameters`, so that codes like "A" (Annual) or "W00" (World) become self-explanatory labels.
-
-For example, suppose we want to decode the `frequency`, `country`, and `type_of_transformation` (unit) columns in our dataset. We'll merge the parameter descriptions into our data frame:
+You can check which agency publishes a dataset with `imf_get_dataflows`, and filter the returned data yourself:
 
 ``` {python}
-# Decode frequency codes (e.g., "A" → "Annual")
-decoded_df = df.merge(
-    # Select code-description pairs
-    params['frequency'][['input_code', 'description']],
-    # Match codes in the data frame
-    left_on='frequency',
-    # ...to codes in the parameter data
-    right_on='input_code',
-    # Keep all data rows
-    how='left'
-).drop(columns=['frequency', 'input_code']
-).rename(columns={"description": "frequency"})
+subset = df[df["TIME_PERIOD"].between("2000", "2015")]
+subset["TIME_PERIOD"].agg(["min", "max"])
+```
+:::
 
-# Decode geographic area codes (e.g., "W00" → "World")
-decoded_df = decoded_df.merge(
-    params['country'][['input_code', 'description']],
-    left_on='country',
-    right_on='input_code',
-    how='left'
-).drop(columns=['country', 'input_code']
-).rename(columns={"description":"country"})
+## Empty Results
 
-# Decode unit codes (e.g., "IX" → "Index")
-decoded_df = decoded_df.merge(
-    params['type_of_transformation'][['input_code', 'description']],
-    left_on='type_of_transformation',
-    right_on='input_code',
-    how='left'
-).drop(columns=['type_of_transformation', 'input_code']
-).rename(columns={"description":"type_of_transformation"})
+A query that matches nothing returns an empty DataFrame and warns, rather than raising. This keeps a query that legitimately has no data from breaking an automated pipeline:
 
-decoded_df.head()
+``` {python}
+#| eval: false
+df = imfp.imf_get("PCPS", indicator="PCOAL", frequency="A", data_transformation="USD")
+if df.empty:
+    print("No observations; try relaxing the filters.")
 ```
 
-After decoding, the data frame is much more human-interpretable. This transformation makes the data more accessible for analysis and presentation, while maintaining all the original information.
+The usual causes are a code that is valid for the dimension but has no data for the rest of your filters, or a combination of filters that is individually valid but jointly empty. Relax one dimension at a time to find out which.
+
+## Validating Codes
+
+`imf_get` checks that the *dimensions* you name belong to the dataset:
+
+``` {python}
+try:
+    imfp.imf_get("PCPS", not_a_dimension="X")
+except ValueError as e:
+    print(e)
+```
+
+It does not check the *codes*, because doing so would mean downloading every codelist before every request — often slower than the request itself. The API is the authority on which codes are valid; use `imf_get_codelists` when you want to check ahead of time.
+
+## Inspecting the Request
+
+`print_url=True` prints the URL being requested, which is the most useful thing to include when reporting a problem with a particular query:
+
+``` {python}
+df = imfp.imf_get(
+    "PCPS", indicator="PCOAL", data_transformation="INDEX", frequency="A",
+    print_url=True,
+)
+```
+
+For the unparsed SDMX-JSON response, use `return_raw=True`:
+
+``` {python}
+raw = imfp.imf_get(
+    "PCPS", indicator="PCOAL", data_transformation="INDEX", frequency="A",
+    return_raw=True,
+)
+list(raw.keys())
+```
+
+## Retries
+
+`max_tries` controls how many times a failed request is retried with exponential backoff. The default is 3:
+
+``` {python}
+#| eval: false
+df = imfp.imf_get("PCPS", indicator="PCOAL", max_tries=5)
+```
+
+See [Rate Limits](rate_limits.qmd) for more on working within the API's limits.

--- a/user-guide/demo.qmd
+++ b/user-guide/demo.qmd
@@ -67,7 +67,7 @@ def load_or_fetch_databases():
 
     # If CSV doesn't exist or couldn't be loaded, fetch from API
     print("Fetching databases from IMF API...")
-    databases = imfp.imf_databases()
+    databases = imfp.imf_get_dataflows()
 
     # Save to CSV for future use
     databases.to_csv(csv_path, index=False)
@@ -89,7 +89,10 @@ def load_or_fetch_parameters(database_name):
 
     # If pickle doesn't exist or couldn't be loaded, fetch from API
     print(f"Fetching parameters for {database_name} from IMF API...")
-    parameters = imfp.imf_parameters(database_name)
+    dimensions = imfp.imf_get_datastructure(database_name)
+    parameters = imfp.imf_get_codelists(
+        list(dimensions["dimension_id"]), database_name
+    )
 
     # Save to pickle file for future use
     os.makedirs("data", exist_ok=True)  # Ensure the data directory exists
@@ -113,7 +116,10 @@ def load_or_fetch_dataset(database_id, indicator):
 
     # If CSV doesn't exist or couldn't be loaded, fetch from API
     print(f"Fetching dataset for {database_id}.{indicator} from IMF API...")
-    dataset = imfp.imf_dataset(database_id=database_id, indicator=[indicator])
+    dataset = imfp.imf_get(database_id, indicator=[indicator])
+    # The cached CSVs below this notebook were written with lower-cased column
+    # names, so normalize the API's SDMX casing to match them.
+    dataset.columns = dataset.columns.str.lower()
 
     # Save to CSV file for future use
     os.makedirs("data", exist_ok=True)  # Ensure the data directory exists
@@ -230,7 +236,9 @@ def load_or_fetch_dataset_with_params(database_id, filename_suffix, **kwargs):
 
     # If CSV doesn't exist or couldn't be loaded, fetch from API
     print(f"Fetching dataset for {database_id}.{filename_suffix} from IMF API...")
-    dataset = imfp.imf_dataset(database_id=database_id, **kwargs)
+    dataset = imfp.imf_get(database_id, **kwargs)
+    # Match the lower-cased column names used by the cached CSVs.
+    dataset.columns = dataset.columns.str.lower()
 
     # Save to CSV file for future use
     os.makedirs("data", exist_ok=True)

--- a/user-guide/demo.qmd
+++ b/user-guide/demo.qmd
@@ -179,10 +179,10 @@ Path("data").mkdir(exist_ok=True)
 # Load or fetch databases
 databases = load_or_fetch_databases()
 
-# Filter out databases that contain a year in the description
+# Filter out databases whose name contains a year
 databases[
-  ~databases['description'].str.contains(r"[\d]{4}", regex=True)
-]
+  ~databases['name'].str.contains(r"[\d]{4}", regex=True)
+][['id', 'name']]
 
 # view_dataframe_in_browser(databases)
 ```
@@ -202,7 +202,7 @@ Note: The Gender Inequality Index (GII) is a UN dataset that is no longer availa
 :::
 
 ```{python}
-databases[databases['database_id'].isin(['QNEA','ANEA','WEO'])]
+databases[databases['id'].isin(['QNEA','ANEA','WEO'])][['id', 'name']]
 ```
 
 Parameters are dictionary key names to make requests from the databases. "country" is the ISO-3 code of the country. "indicator" refers to the code representing a specific dataset in the database.
@@ -215,7 +215,9 @@ params = {}
 for dataset in datasets_list:
     params[dataset] = load_or_fetch_parameters(dataset)
 
-    valid_keys = list(params[dataset].keys())
+    # imf_get_codelists returns one tidy frame, so the dimensions are the
+    # distinct values of its dimension_id column.
+    valid_keys = sorted(params[dataset]["dimension_id"].unique())
     print(f"Parameters for {dataset}: ", valid_keys)
 ```
 

--- a/user-guide/migration.qmd
+++ b/user-guide/migration.qmd
@@ -1,0 +1,167 @@
+---
+title: "Migrating from imfp 1.x"
+---
+
+## What Changed
+
+Version 2.0.0 reorganizes `imfp` around the [econdataverse](https://econdataverse.org/) conventions, matching the R package [imfapi](https://github.com/Teal-Insights/r-imfapi) so that the same workflow reads the same way in both languages. Concretely:
+
+- Functions are named for what they retrieve (`imf_get_*`), and every one returns a tidy DataFrame.
+- Vocabulary follows SDMX, the standard the IMF API actually speaks: *dataflows* rather than databases, *dimensions* rather than parameters, *codes* rather than input codes.
+- `imf_get_codelists` returns a single tidy DataFrame instead of a dict of DataFrames.
+
+The four pre-2.0 functions still work, but each now emits a `DeprecationWarning` and will be removed in 3.0.0.
+
+## Function Mapping
+
+| imfp 1.x | imfp 2.0 | Notes |
+|---|---|---|
+| `imf_databases()` | `imf_get_dataflows()` | Now also returns version, agency, structure, and last-updated columns. |
+| `imf_parameters(db)` | `imf_get_codelists(dims, db)` | Returns one tidy DataFrame instead of a dict of DataFrames. Takes the dimensions you want. |
+| `imf_parameter_defs(db)` | `imf_get_datastructure(db)` | Returns dimension IDs with their type and position. |
+| `imf_dataset(db, ...)` | `imf_get(db, ...)` | Takes plain code strings; returns SDMX-cased columns. |
+
+## Argument Mapping
+
+| imfp 1.x | imfp 2.0 |
+|---|---|
+| `database_id=` | first positional argument, `dataflow_id` |
+| `parameters=` (dict of DataFrames) | `dimensions=` (dict of code lists) |
+| `start_year=` / `end_year=` | `start_period=` / `end_period=` |
+| `times=` | `max_tries=` |
+| `print_url=` | `print_url=` (unchanged) |
+| `return_raw=` | `return_raw=` (unchanged) |
+| `include_metadata=` | removed — use `imf_get_dataflows()` for dataset metadata |
+
+## Side-by-Side
+
+### Listing datasets
+
+``` {python}
+#| eval: false
+# imfp 1.x
+databases = imfp.imf_databases()          # database_id, description
+
+# imfp 2.0
+dataflows = imfp.imf_get_dataflows()      # id, name, description, version, ...
+```
+
+The old `description` column held the dataset's *name*. In 2.0 the name and the description are separate columns.
+
+### Discovering how to filter
+
+``` {python}
+#| eval: false
+# imfp 1.x — a dict of DataFrames, one per parameter
+params = imfp.imf_parameters("PCPS")
+params.keys()
+params["frequency"]                       # input_code, description
+
+# imfp 2.0 — dimensions first, then codes, both tidy
+dims = imfp.imf_get_datastructure("PCPS") # dimension_id, type, position
+codes = imfp.imf_get_codelists("FREQUENCY", "PCPS")
+codes[["code", "name"]]
+```
+
+Note the dimension is now `FREQUENCY`, not `frequency`. Dimension IDs are matched case-insensitively, so either spelling works as an argument, but the values in the returned data keep the SDMX casing.
+
+### Fetching data
+
+``` {python}
+#| eval: false
+# imfp 1.x
+df = imfp.imf_dataset(
+    database_id="PCPS",
+    indicator=["PCOAL"],
+    data_transformation=["INDEX"],
+    frequency=["A"],
+    start_year=2000,
+    end_year=2015,
+)
+
+# imfp 2.0
+df = imfp.imf_get(
+    "PCPS",
+    dimensions={
+        "INDICATOR": ["PCOAL"],
+        "DATA_TRANSFORMATION": ["INDEX"],
+        "FREQUENCY": ["A"],
+    },
+    start_period=2000,
+    end_period=2015,
+)
+```
+
+Keyword-argument style still works, so the shortest migration for many calls is to rename `database_id`, `start_year`, and `end_year`:
+
+``` {python}
+#| eval: false
+df = imfp.imf_get(
+    "PCPS", indicator=["PCOAL"], data_transformation=["INDEX"], frequency=["A"],
+    start_period=2000, end_period=2015,
+)
+```
+
+### Filtering by a DataFrame of parameters
+
+In 1.x you filtered a DataFrame from `imf_parameters` and passed the whole dict back in. In 2.0 you pass plain strings, so take the `code` column:
+
+``` {python}
+#| eval: false
+# imfp 1.x
+params = imfp.imf_parameters("PCPS")
+params["indicator"] = params["indicator"][
+    params["indicator"]["description"].str.contains("Coal")
+]
+df = imfp.imf_dataset("PCPS", parameters=params)
+
+# imfp 2.0
+codes = imfp.imf_get_codelists("INDICATOR", "PCPS")
+coal = codes[codes["name"].str.contains("Coal", na=False)]["code"].tolist()
+df = imfp.imf_get("PCPS", indicator=coal)
+```
+
+Passing a DataFrame where codes are expected raises a `ValueError` that says exactly this, rather than failing obscurely later.
+
+## Column Name Changes
+
+`imf_dataset` lower-cased its columns. `imf_get` keeps the SDMX dimension IDs as the API reports them, which is what `imfapi` does in R:
+
+``` {python}
+#| eval: false
+# imfp 1.x columns
+["country", "indicator", "data_transformation", "frequency", "time_period", "obs_value"]
+
+# imfp 2.0 columns
+["COUNTRY", "INDICATOR", "DATA_TRANSFORMATION", "FREQUENCY", "TIME_PERIOD", "OBS_VALUE"]
+```
+
+If you have downstream code that depends on the old casing, rename after fetching:
+
+``` {python}
+#| eval: false
+df.columns = df.columns.str.lower()
+```
+
+## Behavior Changes
+
+**Empty results no longer raise.** `imf_dataset` raised a `ValueError` when a query matched nothing. `imf_get` returns an empty DataFrame and emits a `UserWarning`, so a legitimately empty query does not break a pipeline. Check `df.empty` where you previously caught the exception.
+
+**`OBS_VALUE` is numeric.** `imf_dataset` returned everything as strings, so guides recommended `pd.to_numeric`. `imf_get` returns `OBS_VALUE` as `float64` already. `TIME_PERIOD` stays a string, since its format varies with frequency.
+
+**Codes are not pre-validated.** `imf_dataset` downloaded every codelist to check your inputs and warned about invalid ones. `imf_get` skips that, which makes requests substantially faster; the API rejects genuinely invalid codes. Use `imf_get_codelists` when you want to check first.
+
+**No parameter-name coercion.** `imf_dataset` quietly rewrote `freq` to `frequency`, `country` to `ref_area`, and so on, warning as it went. `imf_get` does not guess: name the dimension the dataset actually uses. If you are unsure, `imf_get_datastructure` will tell you, and an incorrect name produces an error listing the valid ones.
+
+## Silencing the Deprecation Warnings
+
+If you are not ready to migrate, the old functions keep working through the 2.x series. To silence the warnings in the meantime:
+
+``` {python}
+#| eval: false
+import warnings
+
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="imfp")
+```
+
+They will stop working in 3.0.0, so treat this as a stopgap rather than a fix.

--- a/user-guide/parameters.qmd
+++ b/user-guide/parameters.qmd
@@ -1,166 +1,164 @@
 ---
-title: "Working with Parameters"
+title: "Dimensions and Codes"
 ---
 
-## Filtering IMF Dataset Requests with Parameters
+## Why Filtering Matters
 
-Once you have a `database_id`, it’s possible to make a call to `imf_dataset` to fetch the entire database:
+Once you have a dataflow ID, you can in principle request the whole dataset:
 
 ``` {python}
 #| eval: false
 import imfp
-import pandas as pd
 
-# Set float format to 2 decimal places for pandas display output
-pd.set_option('display.float_format', lambda x: '%.2f' % x)
-
-# Producer Price Index database
-database_id = "PPI"
-imfp.imf_dataset(database_id)
+# Requests all of the Producer Price Index dataset
+imfp.imf_get("PPI")
 ```
 
-However, while this will succeed for a few small databases, it will fail for all of the larger ones. And even in the rare case when it succeeds, fetching an entire database can take a long time. You’re much better off supplying additional filter parameters to reduce the size of your request.
+This succeeds for a few small datasets and fails for all the large ones, and even when it succeeds it is slow. In practice you almost always want to filter.
 
-Requests to databases available through the IMF API are complicated by the fact that each database uses a different set of parameters when making a request. You also have to have the list of valid input codes for each parameter. The `imf_parameters` function solves this problem. Use the function to obtain the full list of parameters and valid input codes for a given database.
+Filtering an IMF dataset takes two pieces of information, and `imfp` has one function for each:
 
-## Understanding Filter Parameters
+- **Which dimensions does this dataset have?** — `imf_get_datastructure`
+- **What values does each dimension accept?** — `imf_get_codelists`
 
-Each database available through the IMF API has its own set of parameters that can be used to filter and specify the data you want to retrieve.
+## Dimensions
 
-Each parameter will be a column in the data. Each row in the data will contain a value for that parameter. The parameter will always be a categorical variable, meaning that it can take only a limited set of values. We refer to these values as "input codes," because you can input them in your API request to filter the data.
+Every dataset is described by a *datastructure definition* (DSD), which lists the **dimensions** the data is broken out by. Each dimension becomes a column in the returned data, and each is categorical: it accepts only a fixed set of values.
 
-What this means, though, is that before making an API request to retrieve data, you need to know what the available filtering parameters are for the database, and what codes you can use for filtering the data by each parameter.
-
-There are two main functions for working with parameters:
-
-- `imf_parameters()`: Get the full list of parameters and valid input codes for a database
-- `imf_parameter_defs()`: Get text descriptions of what each parameter represents
-
-## Discovering Available Parameters
-
-To get started, you'll need to know what parameters are available for your chosen database. Use `imf_parameters()` to get this information:
+Datasets do not share a common set of dimensions. Some use `COUNTRY`, others `REF_AREA`; some spell frequency `FREQUENCY` and others `FREQ`. This is why you have to ask.
 
 ``` {python}
 import imfp
 
-# Fetch list of valid parameters for the Producer Price Index database
-params = imfp.imf_parameters("PPI")
-
-# View the available parameter names
-params.keys()
+dimensions = imfp.imf_get_datastructure("PCPS")
+dimensions
 ```
 
-The function returns a dictionary of data frames.
+The columns are:
 
-Each key in the dictionary corresponds to a parameter used in making requests from the database. The value for each key is a data frame with the following columns:
+| Column | Meaning |
+|---|---|
+| `dimension_id` | The dimension's ID — what you filter on in `imf_get`. |
+| `type` | `Dimension`, `TimeDimension`, or `Measure`. |
+| `position` | The dimension's slot in the dataset's series key. |
 
-- `input_code`: The valid codes you can use for that parameter
-- `description`: A short text description of what each code represents
+### Position
 
-For example, to see the valid codes for the `frequency` parameter:
+`position` is the dimension's slot in the request the API actually receives. IMF requests are *positional*: filters are sent as a dot-separated key in which each slot corresponds to one dimension, in this order, and an unfiltered slot is a wildcard. `imf_get` assembles that key for you, so you never have to think about position — but it explains why the order of dimensions is fixed and worth glancing at.
+
+### Time and Measures
+
+By default `imf_get_datastructure` lists only the dimensions you can filter on. Time is excluded because you filter it through `start_period`/`end_period` rather than through the key, and measures are excluded because they are outputs rather than filters. Ask for them explicitly if you want to see them:
 
 ``` {python}
-# View the data frame of valid input codes for the frequency parameter
-params['frequency']
+imfp.imf_get_datastructure("PCPS", include_time=True, include_measures=True)
 ```
 
-## Parameter Definitions
+Note that the measure has no `position`: it does not occupy a slot in the series key.
 
-If the parameter name is not self-explanatory, you can use the `imf_parameter_defs()` function to get a text description of what each parameter represents.
+## Codes
+
+Knowing that `PCPS` has an `INDICATOR` dimension does not tell you that coal is `PCOAL`. For that, use `imf_get_codelists`, which returns the valid codes for one or more dimensions:
 
 ``` {python}
-# Get descriptions of what each parameter means
-params_defs = imfp.imf_parameter_defs("PPI")
-
-params_defs
+frequencies = imfp.imf_get_codelists("FREQUENCY", "PCPS")
+frequencies[["code", "name"]].head()
 ```
 
-## Supplying Parameters
+The columns are:
 
-### Basic Approach (Recommended for Most Users)
+| Column | Meaning |
+|---|---|
+| `dimension_id` | Which dimension the code belongs to. |
+| `code` | The value to pass to `imf_get`. |
+| `name` | Short human-readable label. |
+| `description` | Longer definition, where the IMF provides one. |
+| `codelist_id` | ID of the codelist this came from, e.g. `CL_FREQ`. |
+| `codelist_agency` | Agency that maintains the codelist. |
+| `codelist_version` | Version of the codelist. |
 
-To make a request to fetch data from the IMF API, just call `imf_dataset` with the database ID and keyword arguments for each parameter, where the keyword argument name is the parameter name and the value is the list of codes you want.
+Dimension IDs are matched case-insensitively, so `"frequency"` and `"FREQUENCY"` both work.
 
-For instance, on exploring the `frequency` parameter of the Producer Price Index database above, we found that the frequency can take one of three values: "A" for annual, "Q" for quarterly, and "M" for monthly. Thus, to request annual data, we can call `imf_dataset` with `frequency = ["A"]`.
+### Fetching Several Dimensions at Once
 
-Here's a complete example that fetches annual producer prices from 2000 to 2015:
+Pass a list to get everything in one tidy frame — one row per code, with `dimension_id` telling you which dimension each row belongs to:
+
+``` {python}
+codes = imfp.imf_get_codelists(
+    ["INDICATOR", "DATA_TRANSFORMATION", "FREQUENCY"], "PCPS"
+)
+codes.groupby("dimension_id").size()
+```
+
+Since it is a single DataFrame, searching it is an ordinary filter:
+
+``` {python}
+codes[
+    (codes["dimension_id"] == "INDICATOR")
+    & codes["name"].str.contains("Coal", case=False, na=False)
+][["code", "name"]]
+```
+
+``` {python}
+codes[codes["dimension_id"] == "DATA_TRANSFORMATION"][["code", "name"]]
+```
+
+To pull every dimension's codes in one call, feed it the datastructure:
 
 ``` {python}
 #| eval: false
-# Example: Get annual prices
-df = imfp.imf_dataset(
-    database_id="PPI",
-    frequency=["A"],  # Annual frequency
-    indicator=["PPI"],  # Producer Price Index
-    start_year=2000,
-    end_year=2015
-)
+all_codes = imfp.imf_get_codelists(list(dimensions["dimension_id"]), "PCPS")
 ```
 
-### Advanced Approaches
+Note that country codelists tend to be large, so this can take a moment.
 
-For more complex queries, there are two programmatic ways to supply parameters to `imf_dataset`. These approaches are particularly useful when you need to filter parameters based on their descriptions or when working with multiple parameter values.
+## Using Codes in a Request
 
-#### 1. List Arguments with Parameter Filtering
-
-This approach uses string matching to find the correct parameter codes before passing them to `imf_dataset`:
+The `code` column holds exactly the values `imf_get` expects:
 
 ``` {python}
-# Fetch the input code column of the frequency parameter...
-selected_frequency = list(
-    params['frequency']['input_code'][
-        # ...where the description contains "Annual"
-        params['frequency']['description'].str.contains("Annual")
-    ]
-)
+coal = codes[
+    (codes["dimension_id"] == "INDICATOR")
+    & (codes["code"] == "PCOAL")
+]["code"].tolist()
 
-# Fetch the input code column of the unit_measure parameter...
-selected_type_of_transformation = list(
-    params['type_of_transformation']['input_code'][
-        # ...where the description contains "Index"
-        params['type_of_transformation']['description'].str.contains("Index")
-    ]
+df = imfp.imf_get(
+    "PCPS",
+    dimensions={
+        "INDICATOR": coal,
+        "DATA_TRANSFORMATION": ["INDEX"],
+        "FREQUENCY": ["A"],
+    },
 )
-
-# Request data from the API using the filtered parameter code lists
-df = imfp.imf_dataset(
-    database_id="PPI",
-    frequency=selected_frequency,
-    type_of_transformation=selected_type_of_transformation,
-    start_year=2000,
-    end_year=2015
-)
-
 df.head()
 ```
 
-#### 2. Parameters Dictionary Approach
+## Labelling Results
 
-This approach modifies the parameters dictionary directly and passes the entire filtered dictionary to `imf_dataset` as a single `parameters` keyword argument. This is more concise but requires understanding how the parameters dictionary works:
+Because the codes and the data are both tidy DataFrames keyed on the code, attaching human-readable labels is a merge:
 
 ``` {python}
-# Copy the params dictionary
-modified_params = params.copy()
+labelled = df.merge(
+    codes[codes["dimension_id"] == "INDICATOR"][["code", "name"]],
+    left_on="INDICATOR",
+    right_on="code",
+    how="left",
+).drop(columns=["code"]).rename(columns={"name": "indicator_name"})
 
-# Overwrite the data frame for each parameter in the dictionary with filtered rows
-modified_params['frequency'] = params['frequency'][
-    # ...where the input code description for frequency contains "Annual"
-    params['frequency']['description'].str.contains("Annual")
-]
-modified_params['type_of_transformation'] = params['type_of_transformation'][
-    # ...where the input code description for type_of_transformation contains "Index"
-    params['type_of_transformation']['description'].str.contains("Index")
-]
-
-# Pass the modified dictionary to imf_dataset
-df = imfp.imf_dataset(
-    database_id="PPI",
-    parameters=modified_params,
-    start_year=2000,
-    end_year=2015
-)
-
-df.head()
+labelled[["INDICATOR", "indicator_name", "TIME_PERIOD", "OBS_VALUE"]].head()
 ```
 
-Note that when using the parameters dictionary approach, you cannot combine it with individual parameter arguments. If you supply a `parameters` argument, any other keyword arguments for individual parameters will be ignored.
+## Handling Unknown Dimensions
+
+Asking for a dimension a dataset does not have is an error, and the message tells you what is available:
+
+``` {python}
+try:
+    imfp.imf_get_codelists("FREQ", "PCPS")
+except ValueError as e:
+    print(e)
+```
+
+## Next Step
+
+With dimension IDs and codes in hand, you are ready to request data. See [Fetching Data](datasets.qmd).

--- a/user-guide/rate_limits.qmd
+++ b/user-guide/rate_limits.qmd
@@ -47,7 +47,7 @@ You can modify retry behavior:
 ``` {python}
 #| eval: false
 # Retry 4 times rather than the default 3
-df = imfp.imf_dataset("PPI", "WPI", times=4)
+df = imfp.imf_get("PPI", indicator="WPI", max_tries=4)
 ```
 
 ### Caching Strategy
@@ -61,21 +61,21 @@ Note that to run this code, you will need to install the `pyarrow` library, whic
 import os
 import pandas as pd
 
-# Fetch imf databases from file if available, else from API
-cache_path = f"data/imf_databases.parquet"
+# Fetch imf dataflows from file if available, else from API
+cache_path = "data/imf_dataflows.parquet"
 if os.path.exists(cache_path):
-    databases = pd.read_parquet(cache_path)
+    dataflows = pd.read_parquet(cache_path)
 else:
-    databases = imfp.imf_databases()
+    dataflows = imfp.imf_get_dataflows()
     os.makedirs("data", exist_ok=True)
-    databases.to_parquet(cache_path)
+    dataflows.to_parquet(cache_path)
 ```
 
 You can also functionalize this logic to permit reuse several times in the same script or notebook. See Jenny Xu's excellent [demo notebook](demo.qmd#utility-functions) for example caching functions.
 
 ## Performance Tips
 
-1. **Filter Early**: Use parameters to limit data at the API level
+1. **Filter Early**: Use dimension filters to limit data at the API level
 2. **Parallelize Carefully**: Avoid running parallel API requests, even from multiple clients
 3. **Use Efficient Formats**: Store cached data in parquet or feather files
 4. **Validate Data**: Check for errors and empty responses

--- a/user-guide/usage.qmd
+++ b/user-guide/usage.qmd
@@ -4,7 +4,7 @@ title: "Suggestions for Usage"
 
 ## Determining Data Availability
 
-The only way to be certain whether data is available for a given set of parameters is to make a request to the API and see if it succeeds. If you get an empty data frame, try a less restrictive version of your request.
+The only way to be certain whether data is available for a given set of dimension filters is to make a request to the API and see what comes back. `imf_get` returns an empty data frame and warns when a query matches nothing; if that happens, relax one dimension at a time to find the one that is over-restrictive.
 
 ## Working with Large Data Frames
 
@@ -21,10 +21,10 @@ import pandas as pd
 # Set float format to 2 decimal places for pandas display output
 pd.set_option('display.float_format', lambda x: '%.2f' % x)
 
-df: pd.DataFrame = imfp.imf_dataset(
-    database_id="PCPS",
+df: pd.DataFrame = imfp.imf_get(
+    "PCPS",
     indicator=["PCOAL"],
-    data_transformation=["IX"]
+    data_transformation=["INDEX"],
 )
 
 # Quick summary of DataFrame
@@ -40,28 +40,16 @@ df.head()
 
 ### Cleaning Data
 
-#### Numeric Conversion
-
-All data is returned from the IMF API as a text (object) data type, so you will want to cast numeric columns to numeric.
-
-``` {python}
-# Numeric columns
-numeric_cols = ["obs_value"]
-
-# Cast numeric columns
-df[numeric_cols] = df[numeric_cols].apply(pd.to_numeric)
-```
-
 #### Categorical Conversion
 
-You can also convert string columns to categorical types for better memory usage.
+`imf_get` already returns `OBS_VALUE` as a float, so no numeric conversion is needed. Dimension columns come back as strings, and converting them to pandas categoricals can save a great deal of memory on large frames:
 
 ``` {python}
-# Convert categorical columns like ref_area and indicator to category type
+# Convert dimension columns to category type
 categorical_cols = [
-  "frequency",
-  "country",
-  "indicator"
+  "FREQUENCY",
+  "COUNTRY",
+  "INDICATOR"
 ]
 
 df[categorical_cols] = df[categorical_cols].astype("category")
@@ -69,7 +57,7 @@ df[categorical_cols] = df[categorical_cols].astype("category")
 
 #### NA Removal
 
-After conversion, you may want to drop any rows with missing values.
+Observations the IMF reports as missing come back as `NaN`, so you may want to drop them:
 
 ``` {python}
 # Drop rows with missing values
@@ -78,27 +66,25 @@ df = df.dropna()
 
 #### Time Period Conversion
 
-The `time_period` column can be more difficult to work with, because it may be differently formatted depending on the frequency of the data.
+The `TIME_PERIOD` column is the awkward one, because its format depends on the frequency of the series.
 
-Annual data will be formatted as a four-digit year, such as "2000", which can be trivially converted to numeric.
-
-However, quarterly data will be formatted as "2000-Q1", monthly data will be formatted like "2000-M01", etc.
+Annual data is formatted as a four-digit year, such as "2000", which converts trivially to numeric. Quarterly data, though, is formatted as "2000-Q1", monthly data as "2000-M01", and so on.
 
 You can use the `pandas` library's `to_datetime()` method with the `format="mixed"` argument to convert this column to a datetime object in a format-agnostic way:
 
 ``` {python}
-# Convert time_period to datetime
-df["datetime"] = pd.to_datetime(df["time_period"], format="mixed")
-df[["frequency", "datetime"]].head()
+# Convert TIME_PERIOD to datetime
+df["datetime"] = pd.to_datetime(df["TIME_PERIOD"], format="mixed")
+df[["FREQUENCY", "datetime"]].head()
 ```
 
-Alternatively, you can split the `time_period` column into separate columns for year, quarter, and month, and then convert each to a numeric value:
+Alternatively, you can split the `TIME_PERIOD` column into separate columns for year, quarter, and month, and then convert each to a numeric value:
 
 ``` {python}
-# Split time_period into separate columns
-df["year"] = df["time_period"].str.extract(r"(\d{4})")[0]
-df["quarter"] = df["time_period"].str.extract(r"[Q](\d{1})")[0]
-df["month"] = df["time_period"].str.extract(r"[M](\d{2})")[0]
+# Split TIME_PERIOD into separate columns
+df["year"] = df["TIME_PERIOD"].str.extract(r"(\d{4})")[0]
+df["quarter"] = df["TIME_PERIOD"].str.extract(r"[Q](\d{1})")[0]
+df["month"] = df["TIME_PERIOD"].str.extract(r"[M](\d{2})")[0]
 
 # Convert year, quarter, and month to numeric
 df["year"] = pd.to_numeric(df["year"])
@@ -106,7 +92,7 @@ df["quarter"] = pd.to_numeric(df["quarter"])
 df["month"] = pd.to_numeric(df["month"])
 
 # Return head for non-na months
-df[["time_period", "year", "quarter", "month"]].dropna(subset=["month"]).head()
+df[["TIME_PERIOD", "year", "quarter", "month"]].dropna(subset=["month"]).head()
 ```
 
 ### Summarizing Data
@@ -159,29 +145,29 @@ First, let's retrieve the key adjustment variables:
 
 ``` {python}
 # Fetch GDP Deflator (Index, Quarterly)
-deflator = imfp.imf_dataset(
-    database_id="QNEA",
+deflator = imfp.imf_get(
+    "QNEA",
     indicator="B1GQ",
     price_type="PD",  # Price deflator
     type_of_transformation="IX",  # Index
     frequency="Q",
-    start_year=2010
+    start_period=2010,
 )
 
 # Fetch Population Estimates (Annual)
-population = imfp.imf_dataset(
-    database_id="WEO",
+population = imfp.imf_get(
+    "WEO",
     indicator="LP",
     frequency="A",
-    start_year=2010
+    start_period=2010,
 )
 
 # Fetch Exchange Rate (Quarterly)
-exchange_rate = imfp.imf_dataset(
-    database_id="ER", 
+exchange_rate = imfp.imf_get(
+    "ER",
     indicator="XDC_USD",  # Domestic currency per USD
     frequency="Q",
-    start_year=2010
+    start_period=2010,
 )
 ```
 
@@ -189,13 +175,13 @@ We'll also retrieve a nominal GDP series to be adjusted:
 
 ``` {python}
 # Fetch Nominal GDP (Domestic currency, annual)
-nominal_gdp = imfp.imf_dataset(
-    database_id="ANEA",
+nominal_gdp = imfp.imf_get(
+    "ANEA",
     indicator="B1GQ",
     price_type="V",  # Current prices
     type_of_transformation="XDC",  # Domestic currency
     frequency="A",
-    start_year=2010
+    start_period=2010,
 )
 ```
 
@@ -217,7 +203,7 @@ The IMF has updated their API structure. The former IFS (International Financial
 - **CPI**: Consumer Price Index data
 - **MFS_CBS**: Monetary and Financial Statistics, Central Bank data
 
-Use `imf_databases()` to see all available databases and `imf_parameters(database_id)` to explore their indicators.
+Use `imf_get_dataflows()` to see all available datasets and `imf_get_datastructure(dataflow_id)` / `imf_get_codelists(dimensions, dataflow_id)` to explore their dimensions and indicators.
 :::
 
 ### Alternative: Using CPI for Price Adjustments
@@ -226,13 +212,13 @@ If you prefer to use the Consumer Price Index instead of the GDP deflator:
 
 ``` {python}
 # Fetch CPI (All Items, Index)
-cpi = imfp.imf_dataset(
-    database_id="CPI",
+cpi = imfp.imf_get(
+    "CPI",
     index_type="CPI",
     coicop_1999="_T",  # All Items
     type_of_transformation="IX",  # Index
     frequency="Q",
-    start_year=2010
+    start_period=2010,
 )
 ```
 
@@ -244,12 +230,12 @@ When working with data of different frequencies, you'll often need to harmonize 
 
 ```{python}
 # Keep only Q4 observations for annual comparisons
-deflator = deflator[deflator['time_period'].str.contains("Q4")]
-exchange_rate = exchange_rate[exchange_rate['time_period'].str.contains("Q4")]
+deflator = deflator[deflator["TIME_PERIOD"].str.contains("Q4")]
+exchange_rate = exchange_rate[exchange_rate["TIME_PERIOD"].str.contains("Q4")]
 
 # Extract just the year from the time period for Q4 data
-deflator['time_period'] = deflator['time_period'].str[:4]
-exchange_rate['time_period'] = exchange_rate['time_period'].str[:4]
+deflator["TIME_PERIOD"] = deflator["TIME_PERIOD"].str[:4]
+exchange_rate["TIME_PERIOD"] = exchange_rate["TIME_PERIOD"].str[:4]
 ```
 
 ``` {python}
@@ -257,7 +243,7 @@ exchange_rate['time_period'] = exchange_rate['time_period'].str[:4]
 #| echo: false
 # Hidden fixup to filter out exchange rate data before 2010
 # Remove this line when the start_year parameter is fixed for this query
-exchange_rate = exchange_rate[exchange_rate['time_period'].astype(int) > 2010]
+exchange_rate = exchange_rate[exchange_rate["TIME_PERIOD"].astype(int) > 2010]
 ```
 
 2. Calculating annual averages: This approach is more appropriate for flow variables (measurements over a period) and when you want to smooth out seasonal variations:
@@ -266,10 +252,10 @@ exchange_rate = exchange_rate[exchange_rate['time_period'].astype(int) > 2010]
 #| eval: false
 # Alternative: Calculate annual averages
 deflator = deflator.groupby(
-    ['country', deflator['time_period']], 
+    ["COUNTRY", deflator["TIME_PERIOD"]],
     as_index=False
 ).agg({
-    'obs_value': 'mean'
+    "OBS_VALUE": "mean"
 })
 ```
 
@@ -277,23 +263,23 @@ Choose the appropriate method based on your specific analysis needs and the econ
 
 ### Merging Datasets
 
-We can combine the datasets using `pd.DataFrame.merge()` with `country` and `time_period` as keys:
+We can combine the datasets using `pd.DataFrame.merge()` with `COUNTRY` and `TIME_PERIOD` as keys:
 
 ``` {python}
 merged = (
     nominal_gdp.merge(
         deflator,
-        on=['country', 'time_period'],
-        suffixes=('_gdp', '_deflator')
+        on=["COUNTRY", "TIME_PERIOD"],
+        suffixes=("_gdp", "_deflator")
     )
     .merge(
         population,
-        on=['country', 'time_period']
+        on=["COUNTRY", "TIME_PERIOD"]
     )
     .merge(
         exchange_rate,
-        on=['country', 'time_period'],
-        suffixes=('_population', '_exchange_rate')
+        on=["COUNTRY", "TIME_PERIOD"],
+        suffixes=("_population", "_exchange_rate")
     )
 )
 ```
@@ -304,15 +290,15 @@ With the merged dataset, we can now calculate real GDP and per capita values:
 
 ``` {python}
 # Convert nominal to real GDP
-merged['real_gdp'] = (
-    (merged['obs_value_gdp'] / merged['obs_value_deflator']) * 100
+merged["real_gdp"] = (
+    (merged["OBS_VALUE_gdp"] / merged["OBS_VALUE_deflator"]) * 100
 )
 
-# Calculate per capita values (using population obs_value)
-merged['real_gdp_per_capita'] = merged['real_gdp'] / merged['obs_value_population']
+# Calculate per capita values (using population OBS_VALUE)
+merged["real_gdp_per_capita"] = merged["real_gdp"] / merged["OBS_VALUE_population"]
 
 # Display the first 5 rows of the transformed data
-merged[['country', 'time_period', 'real_gdp', 'real_gdp_per_capita']].head()
+merged[["COUNTRY", "TIME_PERIOD", "real_gdp", "real_gdp_per_capita"]].head()
 ```
 
 ### Exchange Rate Adjustment
@@ -320,17 +306,17 @@ merged[['country', 'time_period', 'real_gdp', 'real_gdp_per_capita']].head()
 Note that this result is still in the domestic currency of the country. If you need to convert to a common currency, you can use the exchange rate data from the ER (Exchange Rates) database.
 
 ``` {python}
-# Because 'obs_value_exchange_rate' is local-currency-per-USD,
+# Because "OBS_VALUE_exchange_rate" is local-currency-per-USD,
 # dividing local-currency real GDP by it yields GDP in USD.
 merged["real_gdp_usd"] = (
-    merged["real_gdp"] / merged["obs_value_exchange_rate"]
+    merged["real_gdp"] / merged["OBS_VALUE_exchange_rate"]
 )
 
 # (Optional) real GDP per capita in USD
 merged["real_gdp_usd_per_capita"] = (
-    merged["real_gdp_usd"] / merged["obs_value_population"]
+    merged["real_gdp_usd"] / merged["OBS_VALUE_population"]
 )
 
 # Inspect results
-merged[["time_period","country","real_gdp","real_gdp_usd","real_gdp_usd_per_capita"]].head()
+merged[["TIME_PERIOD","COUNTRY","real_gdp","real_gdp_usd","real_gdp_usd_per_capita"]].head()
 ```

--- a/uv.lock
+++ b/uv.lock
@@ -854,8 +854,6 @@ source = { editable = "." }
 dependencies = [
     { name = "pandas" },
     { name = "requests" },
-    { name = "type-enforced", version = "1.10.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "type-enforced", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -896,7 +894,6 @@ dev = [
 requires-dist = [
     { name = "pandas", specifier = "==2.2.3" },
     { name = "requests", specifier = "==2.33.0" },
-    { name = "type-enforced", specifier = ">=1.10.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -3385,32 +3382,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/43/78a658d18b2a4ccf35b053392f2213bf12e3c63b2abea512d3b6751d1f4c/ty-0.0.69-py3-none-win32.whl", hash = "sha256:ec460e01586b1eb91894c4a8403bee3e045a47e7a4ada943cc27ce8e348e88cf", size = 11787774, upload-time = "2026-08-06T10:04:18.622Z" },
     { url = "https://files.pythonhosted.org/packages/3a/5e/88db1f674403f2b81316a853a44a81ed220621fa96f8f7ae586fb6ca7513/ty-0.0.69-py3-none-win_amd64.whl", hash = "sha256:18976ca26a4e28fc3249477f79a695d5502e670803f2e080d89ac905baef3c6e", size = 12864038, upload-time = "2026-08-06T10:04:20.748Z" },
     { url = "https://files.pythonhosted.org/packages/4d/7b/6fc6efd00c69103d70f2bdbe824343089cd70b17b3079170057d3e5a3ac0/ty-0.0.69-py3-none-win_arm64.whl", hash = "sha256:7d4ca3bb74d91cb9947ba3f3b4cb131ad6a2b3ecc76d34040c4ec6092d2e411d", size = 12196693, upload-time = "2026-08-06T10:04:22.902Z" },
-]
-
-[[package]]
-name = "type-enforced"
-version = "1.10.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/6c/3e39989a24bc364f1469b695555c4fe77caadff1ed0bb6ddc63514a443ed/type_enforced-1.10.2.tar.gz", hash = "sha256:a23907b943711acc25760236cf8d6c1742f44d2b55b60b1bb4afac3ae61b05cc", size = 23420, upload-time = "2025-03-05T20:06:33.029Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/4e/f449d99089ac47040bbfa03949ce14956b5f4ec23ca103a0c47716d22c24/type_enforced-1.10.2-py3-none-any.whl", hash = "sha256:4a85fa440e8451310eb1038c55f4296f42e65ead0b34a14947a5b0d79d2c8a9d", size = 16501, upload-time = "2025-03-05T20:06:23.606Z" },
-]
-
-[[package]]
-name = "type-enforced"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
-    "python_full_version == '3.11.*'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/cd/39228f1927fbafe21018244582368667521ee4662892c6b48aa89d6c9afc/type_enforced-2.3.0.tar.gz", hash = "sha256:de75ab9198b869c003d02f331f7ff40ee816760760420e9d80e054e0b3bc360c", size = 32286, upload-time = "2025-11-04T16:29:19.377Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/cb/ff0f60eb34283fb233fd3556331a81efdfbd8a9bdcb5601e1e10a8c6ffd8/type_enforced-2.3.0-py3-none-any.whl", hash = "sha256:c804771d5645f916517c7e4b3424651a34b5b4dc3683d804f947e9b7bc3f7f2c", size = 22149, upload-time = "2025-11-04T16:29:13.888Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -849,7 +849,7 @@ wheels = [
 
 [[package]]
 name = "imfp"
-version = "1.3.4"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "pandas" },


### PR DESCRIPTION
## Summary

This release reorganizes `imfp` around the [econdataverse](https://econdataverse.org/) conventions, aligning the Python package with the R package [imfapi](https://github.com/Teal-Insights/r-imfapi). The new API uses consistent naming (`imf_get_*`), SDMX vocabulary, and returns tidy DataFrames for all operations.

## Key Changes

### New Econdataverse-Style API (`imfp/api.py`)
- **`imf_get_dataflows()`**: Discover available datasets with metadata (version, agency, structure, last_updated)
- **`imf_get_datastructure(dataflow_id, ...)`**: Retrieve dimension definitions with type and position information
- **`imf_get_codelists(dimensions, dataflow_id, ...)`**: Fetch valid codes for specified dimensions as a single tidy DataFrame
- **`imf_get(dataflow_id, dimensions=None, period_start=None, period_end=None, ...)`**: Retrieve observations filtered by dimensions and time periods
- All functions return pandas DataFrames with SDMX-cased column names (e.g., `TIME_PERIOD`, `OBS_VALUE`)

### Backward Compatibility (`imfp/data.py`)
- Retained legacy functions (`imf_databases`, `imf_parameters`, `imf_parameter_defs`, `imf_dataset`) with deprecation warnings
- Legacy functions now delegate to new API implementations
- Maintains existing behavior for users on v1.x

### Enhanced Utilities (`imfp/utils.py`)
- Refactored parsing logic to support both legacy and new API formats
- Added `_parse_imf_sdmx_json()` for SDMX JSON message parsing
- Added `_get_dataflow_rows()`, `_dsd_component_rows()`, `_component_codelist()` for structured data extraction
- Added `_build_data_request()` for constructing API requests with dimension filters
- Added `_annotation_value()` for extracting annotated values from SDMX structures
- Improved error handling and validation for resource paths vs. full URLs

### Documentation Updates
- **New migration guide** (`user-guide/migration.qmd`): Maps v1.x functions to v2.0 equivalents with examples
- Updated existing guides to reference new API functions
- Updated README with new quick-start example
- Updated index page with econdataverse conventions explanation

### Testing
- Added comprehensive test suite (`tests/test_api.py`) for new API functions
- Tests run offline using cached responses keyed by request URL SHA256
- Covers all four main functions and their parameter variations

### Version & Metadata
- Bumped version to 2.0.0 in `pyproject.toml`
- Updated package docstring in `__init__.py` to document new API structure

## Notable Implementation Details

- **Dimension normalization**: Accepts dimension filters as dicts or kwargs, with automatic upper-casing for case-insensitive access
- **Period handling**: Supports both scalar years and SDMX-style period strings (e.g., "2015-Q1", "2015-M01")
- **Flexible code input**: Accepts scalar codes or lists; automatically wraps scalars into lists
- **SDMX compliance**: Uses proper SDMX terminology (dataflows, dimensions, codes) throughout the new API
- **Rate limiting**: Preserved existing rate-limit management via `IMF_WAIT_TIME` environment variable
- **Caching support**: Maintained response caching infrastructure for offline testing

https://claude.ai/code/session_01JG8Su3dHJMQxCh9r5zUM6V